### PR TITLE
feat: SVG background sectors for CircleLayout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,18 +21,23 @@ Open source React Native library for arranging components in a circular layout. 
 Components are positioned using polar-to-Cartesian conversion (x = r·cosθ, y = r·sinθ). Each child is wrapped in `CircleLayoutComponent` which handles absolute positioning and animation. Shared layout/animation props flow via React Context rather than prop-drilling.
 
 ```
-CircleLayout (ref prop)
-  └─ CircleLayoutContext          ← radius, totalParts, startAngle, animationProps
-       └─ CircleLayoutComponent[] ← one per child; handles position + animation
-            └─ useAnimation       ← per-axis Animated.Value (opacity, radius, radians)
-                 └─ useCombinedAnimation ← parallel/sequence orchestration
+CircleLayout (validates props, ref prop)
+  └─ CircleLayoutProvider
+       └─ CircleLayoutContext     ← radius, totalParts, startAngle, sectorAngle, animationProps
+            └─ CircleLayoutContent
+                 ├─ Bg[]          ← one per component; animated background sector (bgConfig)
+                 │    └─ useAnimatedSectorPath ← derives SVG path from (possibly animated) radius/angle
+                 └─ CircleLayoutArray
+                      └─ CircleLayoutComponent[] ← one per child; handles position + animation
+                           └─ useAnimation       ← per-axis Animated.Value (opacity, radius, radians)
+                                └─ useCombinedAnimation ← parallel/sequence orchestration
 ```
 
-**Key invariant:** `totalParts = components.length` for full circles, `components.length - 1` for partial arcs — so the last component lands exactly on `startAngle + sweepAngle`, not one step past it. See `docs/adr/0002-totalparts-invariant-for-partial-arcs.md`.
+**Key invariant:** `totalParts = components.length` for full circles, `components.length - 1` for partial arcs — so the last component lands exactly on `startAngle + sweepAngle`, not one step past it. This branching lives in `CircleLayoutProvider.tsx` (`totalParts` useMemo). See `docs/adr/0002-totalparts-invariant-for-partial-arcs.md`.
 
 **Public API surface** (exported from `src/index.tsx`):
 - `CircleLayout` — main component (ref prop)
-- `CircleLayoutProps`, `CircleLayoutRef` — prop and ref types
+- `CircleLayoutProps`, `CircleLayoutRef`, `AnimationConfig`, `BgConfig` — prop, ref, and config types
 - `AnimationType`, `AnimationCombinationType` — enums
 
 ## Agent skills

--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ _type_: [AnimationProps](#animationprops-1)
 
 _description_: The properties to configure the entry and exit animation of the component.
 
+### `bgConfig`
+
+_type_: [BgConfig](#bgconfig)
+
+_default value_: `undefined`
+
+_description_: The configuration for the background sectors drawn behind each component on the circle. If this prop is not provided, then no background is shown.
+
 ## Methods
 
 These methods are available via the `ref` prop on `CircleLayout`.
@@ -145,15 +153,20 @@ Hides all circle-layout components. Triggers the exit animation on each componen
 ```ts
 export type AnimationProps = {
   /**
-   * Array of animations to be performed on entry and exit of components.
+   * The configuration for the animation. The key of the record is the type of
+   * animation and the value is the configuration for that animation. If a
+   * particular animation type is not provided, then that animation will not
+   * be performed.
+   *
+   * The order of the animation is determined by the key order of the object.
    */
-  animationConfigs: AnimationConfig[];
+  animationConfigs: Partial<Record<AnimationType, AnimationConfig>>;
   /**
    * The type of composition animation to be performed with
    * all the animation configs provided.
    *
    * For those composition which perform animation in a particular order,
-   * the order is picked by the order in the animationConfig array.
+   * the order is picked by the key order of the animationConfigs object.
    */
   animationCombinationType: AnimationCombinationType;
   /**
@@ -164,41 +177,33 @@ export type AnimationProps = {
 };
 ```
 
+```ts
+// Example
+{
+  animationConfigs: {
+    [AnimationType.OPACITY]: {
+      duration: 500,
+      easing: Easing.inOut(Easing.ease),
+    },
+    [AnimationType.LINEAR]: {
+      duration: 500,
+    },
+  },
+  animationCombinationType: AnimationCombinationType.PARALLEL,
+}
+```
+
 ### AnimationConfig
 
 ```ts
-export type AnimationConfig = {
-  /**
-   * The type of animation to be performed.
-   */
-  animationType: AnimationType;
-  /**
-   * The configuration for the animation.
-   */
-  config?: {
-    /**
-     * The duration of the animation in milliseconds.
-     * @default 500
-     */
-    duration?: number;
-    /**
-     * The delay before the animation starts in milliseconds.
-     * @default 0
-     */
-    delay?: number;
-    /**
-     * The easing function to be used for the animation.
-     * @default Easing.inOut(Easing.ease)
-     */
-    easing?: EasingFunction;
-    /**
-     * Flag to indicate if this animation creates an "interaction
-     * handle" on the InteractionManager.
-     * @default true.
-     */
-    isInteraction?: boolean | undefined;
-  };
-};
+/**
+ * The configuration for the animation.
+ * @see https://reactnative.dev/docs/animated#timing
+ */
+export type AnimationConfig = Omit<
+  Animated.TimingAnimationConfig,
+  'toValue' | 'useNativeDriver'
+>;
 ```
 
 ### AnimationType
@@ -208,16 +213,16 @@ export enum AnimationType {
   /**
    * The component will fade in on entry and fade out on exit.
    */
-  OPACITY = 'OPACITY',
+  OPACITY = 'opacityAnimationConfig',
   /**
    * The component will move from the center to its final position.
    */
-  LINEAR = 'LINEAR',
+  LINEAR = 'linearAnimationConfig',
   /**
    * The component will move along the circumference of the circle
    * from the position of the first component to its final position.
    */
-  CIRCULAR = 'CIRCULAR',
+  CIRCULAR = 'circularAnimationConfig',
 }
 ```
 
@@ -228,12 +233,48 @@ export enum AnimationCombinationType {
   /**
    * The animations will be performed in parallel.
    */
-  PARALLEL = 'PARALLEL',
+  PARALLEL = 'parallel',
   /**
    * The animations will be performed in sequence.
    */
-  SEQUENCE = 'SEQUENCE',
+  SEQUENCE = 'sequence',
 }
+```
+
+### BgConfig
+
+```ts
+export type BgConfig = {
+  /**
+   * The fill color for the background of the circle layout.
+   * @default '#3d19e0'
+   */
+  color?: string;
+  /**
+   * The stroke color for the divider lines in the background.
+   * @default color
+   */
+  strokeColor?: string;
+  /**
+   * The width of the stroke for the divider lines in the background.
+   * @default 1
+   */
+  strokeWidth?: number;
+  /**
+   * The radius of the inner circle in the background.
+   *
+   * If this prop is not provided, the background is a filled circle with
+   * the radius provided in CircleLayoutProps. If provided, the background
+   * is a donut shape between innerRadius and the outer radius.
+   * @default 0
+   */
+  innerRadius?: number;
+  /**
+   * The radius of the outer circle in the background.
+   * @default radius provided in CircleLayoutProps
+   */
+  outerRadius?: number;
+};
 ```
 
 ## Authors

--- a/docs/adr/0002-totalparts-invariant-for-partial-arcs.md
+++ b/docs/adr/0002-totalparts-invariant-for-partial-arcs.md
@@ -23,6 +23,6 @@ Using `totalParts = n` would place the last component one step short of the endp
 
 ## Consequences
 
-- This branching logic lives in `CircleLayout.tsx` (`totalParts` useMemo)
+- This branching logic lives in `CircleLayoutProvider.tsx` (`totalParts` useMemo)
 - Any code that computes per-component angles must use `totalParts` from context, not `components.length` directly
 - Adding or removing components changes `totalParts` and thus repositions all components — this is expected behaviour

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,16 +1,16 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { ThemeProvider } from '@shopify/restyle';
 import * as React from 'react';
+import { StatusBar } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { AppContext, type AppContextValue } from './AppContext';
 import type { PopUpProps } from './design_system/molecules/PopUp/PopUp';
 import PopUp from './design_system/molecules/PopUp/PopUp';
-import { RootScreens, type RootStackParamList } from './navigation';
-import { Home, Playground, RadialMenu } from './screens';
-import { ThemeProvider } from '@shopify/restyle';
 import theme from './design_system/style';
-import { StatusBar } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { RootScreens, type RootStackParamList } from './navigation';
+import { Home, NestedRingMenu, Playground, RadialMenu } from './screens';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -39,6 +39,10 @@ const App = () => {
               <Stack.Screen
                 component={RadialMenu}
                 name={RootScreens.RADIAL_MENU}
+              />
+              <Stack.Screen
+                component={NestedRingMenu}
+                name={RootScreens.NESTED_RING_MENU}
               />
             </Stack.Navigator>
           </NavigationContainer>

--- a/example/src/navigation/constants.ts
+++ b/example/src/navigation/constants.ts
@@ -2,4 +2,5 @@ export enum RootScreens {
   PLAYGROUND = 'Playground',
   HOME = 'Home',
   RADIAL_MENU = 'RadialMenu',
+  NESTED_RING_MENU = 'NestedRingMenu',
 }

--- a/example/src/navigation/types.ts
+++ b/example/src/navigation/types.ts
@@ -6,6 +6,7 @@ export type RootStackParamList = {
   [RootScreens.PLAYGROUND]: undefined;
   [RootScreens.HOME]: undefined;
   [RootScreens.RADIAL_MENU]: undefined;
+  [RootScreens.NESTED_RING_MENU]: undefined;
 };
 
 export type RootStackScreenProps<T extends keyof RootStackParamList> =

--- a/example/src/screens/NestedRingMenu/NestedRingMenu.tsx
+++ b/example/src/screens/NestedRingMenu/NestedRingMenu.tsx
@@ -1,0 +1,116 @@
+import { AntDesign } from '@expo/vector-icons';
+import * as React from 'react';
+import { View } from 'react-native';
+import {
+  AnimationCombinationType,
+  AnimationType,
+  CircleLayout,
+  type CircleLayoutRef,
+} from 'react-native-circle-layout';
+
+type Icon = keyof typeof AntDesign.glyphMap;
+
+const icons: Icon[] = ['edit', 'home', 'star', 'delete', 'search', 'setting'];
+const subIcons: Icon[] = ['group', 'idcard', 'phone', 'camera'];
+
+const Component = ({ icon, rotation }: { icon: Icon; rotation: number }) => {
+  const circleLayoutRef = React.useRef<CircleLayoutRef>(null);
+  const [showCircleComponent, setShowCircleComponent] = React.useState(false);
+
+  React.useEffect(() => {
+    if (showCircleComponent) {
+      circleLayoutRef.current?.showComponents();
+    } else {
+      circleLayoutRef.current?.hideComponents();
+    }
+  }, [showCircleComponent]);
+
+  return (
+    <CircleLayout
+      centerComponent={
+        <AntDesign.Button
+          backgroundColor="white"
+          borderRadius={100}
+          color="black"
+          style={{ justifyContent: 'center', height: 50, width: 50 }}
+          iconStyle={{ marginRight: 0 }}
+          name={icon}
+          onPress={() => setShowCircleComponent((oldValue) => !oldValue)}
+        />
+      }
+      components={subIcons.map((subIcon) => (
+        <AntDesign.Button
+          key={subIcon}
+          backgroundColor="white"
+          borderRadius={100}
+          color="black"
+          style={{ justifyContent: 'center', height: 50, width: 50 }}
+          iconStyle={{ marginRight: 0 }}
+          name={subIcon}
+          onPress={() => {}}
+        />
+      ))}
+      animationProps={{
+        animationCombinationType: AnimationCombinationType.PARALLEL,
+        animationConfigs: {
+          [AnimationType.LINEAR]: { duration: 500 },
+          [AnimationType.OPACITY]: { duration: 500 },
+        },
+      }}
+      radius={80}
+      ref={circleLayoutRef}
+      startAngle={rotation}
+      sweepAngle={Math.PI}
+    />
+  );
+};
+
+const NestedRingMenu = () => {
+  const [showCircleComponent, setShowCircleComponent] = React.useState(false);
+  const circleLayoutRef = React.useRef<CircleLayoutRef>(null);
+
+  React.useEffect(() => {
+    if (showCircleComponent) {
+      circleLayoutRef.current?.showComponents();
+    } else {
+      circleLayoutRef.current?.hideComponents();
+    }
+  }, [showCircleComponent]);
+
+  return (
+    <View style={{ flex: 1 }}>
+      <CircleLayout
+        centerComponent={
+          <AntDesign.Button
+            backgroundColor="white"
+            borderRadius={100}
+            color="black"
+            style={{ justifyContent: 'center', height: 50, width: 50 }}
+            iconStyle={{ marginRight: 0 }}
+            name={showCircleComponent ? 'close' : 'appstore'}
+            onPress={() => setShowCircleComponent((oldValue) => !oldValue)}
+          />
+        }
+        components={icons.map((icon, index) => {
+          const sectionAngle = (2 * Math.PI) / icons.length;
+          const rotation = index * sectionAngle - Math.PI / 2;
+          return <Component key={icon} icon={icon} rotation={rotation} />;
+        })}
+        containerStyle={{ bottom: 10, left: 0, position: 'absolute', right: 0 }}
+        animationProps={{
+          animationCombinationType: AnimationCombinationType.PARALLEL,
+          animationConfigs: {
+            [AnimationType.LINEAR]: { duration: 500 },
+            [AnimationType.OPACITY]: { duration: 500 },
+          },
+        }}
+        radius={80}
+        ref={circleLayoutRef}
+        startAngle={0}
+        sweepAngle={Math.PI * 2}
+      />
+    </View>
+  );
+};
+
+export default NestedRingMenu;

--- a/example/src/screens/NestedRingMenu/NestedRingMenu.tsx
+++ b/example/src/screens/NestedRingMenu/NestedRingMenu.tsx
@@ -11,6 +11,7 @@ import {
 type Icon = keyof typeof AntDesign.glyphMap;
 
 const icons: Icon[] = ['edit', 'home', 'star', 'delete', 'search', 'setting'];
+const SECTION_ANGLE = (2 * Math.PI) / icons.length;
 const subIcons: Icon[] = ['group', 'idcard', 'phone', 'camera'];
 
 const Component = ({ icon, rotation }: { icon: Icon; rotation: number }) => {
@@ -26,42 +27,56 @@ const Component = ({ icon, rotation }: { icon: Icon; rotation: number }) => {
   }, [showCircleComponent]);
 
   return (
-    <CircleLayout
-      centerComponent={
-        <AntDesign.Button
-          backgroundColor="white"
-          borderRadius={100}
-          color="black"
-          style={{ justifyContent: 'center', height: 50, width: 50 }}
-          iconStyle={{ marginRight: 0 }}
-          name={icon}
-          onPress={() => setShowCircleComponent((oldValue) => !oldValue)}
-        />
-      }
-      components={subIcons.map((subIcon) => (
-        <AntDesign.Button
-          key={subIcon}
-          backgroundColor="white"
-          borderRadius={100}
-          color="black"
-          style={{ justifyContent: 'center', height: 50, width: 50 }}
-          iconStyle={{ marginRight: 0 }}
-          name={subIcon}
-          onPress={() => {}}
-        />
-      ))}
-      animationProps={{
-        animationCombinationType: AnimationCombinationType.PARALLEL,
-        animationConfigs: {
-          [AnimationType.LINEAR]: { duration: 500 },
-          [AnimationType.OPACITY]: { duration: 500 },
-        },
-      }}
-      radius={80}
-      ref={circleLayoutRef}
-      startAngle={rotation}
-      sweepAngle={Math.PI}
-    />
+    <View style={{ transform: [{ rotate: `${rotation}rad` }] }}>
+      <CircleLayout
+        centerComponent={
+          <AntDesign.Button
+            backgroundColor="transparent"
+            borderRadius={100}
+            color="black"
+            style={{
+              justifyContent: 'center',
+              height: 50,
+              width: 50,
+              transform: [{ rotate: `${-rotation}rad` }],
+            }}
+            iconStyle={{ marginRight: 0 }}
+            name={icon}
+            onPress={() => setShowCircleComponent((oldValue) => !oldValue)}
+          />
+        }
+        components={subIcons.map((subIcon) => (
+          <AntDesign.Button
+            key={subIcon}
+            backgroundColor="transparent"
+            borderRadius={100}
+            color="black"
+            style={{
+              justifyContent: 'center',
+              height: 30,
+              width: 30,
+              transform: [{ rotate: `${-rotation}rad` }],
+            }}
+            iconStyle={{ marginRight: 0 }}
+            name={subIcon}
+            onPress={() => {}}
+            size={12}
+          />
+        ))}
+        animationProps={{
+          animationCombinationType: AnimationCombinationType.PARALLEL,
+          animationConfigs: {
+            [AnimationType.LINEAR]: { duration: 500 },
+            [AnimationType.OPACITY]: { duration: 500 },
+          },
+        }}
+        radius={60}
+        ref={circleLayoutRef}
+        startAngle={SECTION_ANGLE / 2}
+        sweepAngle={SECTION_ANGLE * 2}
+        bgConfig={{ color: '#e8327b', outerRadius: 80, innerRadius: 40 }}
+      />
+    </View>
   );
 };
 
@@ -82,9 +97,9 @@ const NestedRingMenu = () => {
       <CircleLayout
         centerComponent={
           <AntDesign.Button
-            backgroundColor="white"
+            backgroundColor="black"
             borderRadius={100}
-            color="black"
+            color="white"
             style={{ justifyContent: 'center', height: 50, width: 50 }}
             iconStyle={{ marginRight: 0 }}
             name={showCircleComponent ? 'close' : 'appstore'}
@@ -92,8 +107,7 @@ const NestedRingMenu = () => {
           />
         }
         components={icons.map((icon, index) => {
-          const sectionAngle = (2 * Math.PI) / icons.length;
-          const rotation = index * sectionAngle - Math.PI / 2;
+          const rotation = index * SECTION_ANGLE - Math.PI / 2;
           return <Component key={icon} icon={icon} rotation={rotation} />;
         })}
         containerStyle={{ bottom: 10, left: 0, position: 'absolute', right: 0 }}
@@ -104,10 +118,11 @@ const NestedRingMenu = () => {
             [AnimationType.OPACITY]: { duration: 500 },
           },
         }}
-        radius={80}
+        radius={120}
         ref={circleLayoutRef}
         startAngle={0}
         sweepAngle={Math.PI * 2}
+        bgConfig={{ color: '#e8327bc0', innerRadius: 40, outerRadius: 120 }}
       />
     </View>
   );

--- a/example/src/screens/Playground/Playground.tsx
+++ b/example/src/screens/Playground/Playground.tsx
@@ -15,7 +15,6 @@ import {
 } from 'react-native-circle-layout';
 
 const Playground = () => {
-  const [showInitial, setShowInitial] = React.useState(false);
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const viewFlexDirection = React.useMemo(
     () => (windowHeight > windowWidth ? 'column' : 'row'),
@@ -130,7 +129,6 @@ const Playground = () => {
           />
           <SliderWithLabel
             label="Number of Points"
-            isDisabled={showInitial}
             maximumValue={20}
             minimumValue={2}
             onValueChange={setNumberOfPoints}
@@ -163,19 +161,17 @@ const Playground = () => {
         <View gap="s" width="90%">
           <Button
             onPress={() => {
-              setShowInitial(true);
               setShowCircle((oldValue) => !oldValue);
             }}
             label={showCircle ? 'Hide circle layout' : 'Show circle layout'}
           />
           <Button
             onPress={() => {
-              setShowInitial(false);
               setShowCircle(false);
               setRadius(100);
               setSweepAngle(2 * Math.PI);
               setStartAngle(0);
-              setNumberOfPoints(2);
+              setNumberOfPoints(10);
             }}
             label="Reset"
           />

--- a/example/src/screens/Playground/Playground.tsx
+++ b/example/src/screens/Playground/Playground.tsx
@@ -10,6 +10,7 @@ import {
   AnimationCombinationType,
   AnimationType,
   CircleLayout,
+  type AnimationConfig,
   type CircleLayoutRef,
 } from 'react-native-circle-layout';
 
@@ -70,10 +71,15 @@ const Playground = () => {
           animationCombinationType: isParallelAnimation
             ? AnimationCombinationType.PARALLEL
             : AnimationCombinationType.SEQUENCE,
-          animationConfigs: animationTypeList.map((animationType) => ({
-            config: { duration: 500 },
-            type: animationType,
-          })),
+          animationConfigs: animationTypeList.reduce<
+            Partial<Record<AnimationType, AnimationConfig>>
+          >(
+            (acc, animationType) => ({
+              ...acc,
+              [animationType]: { duration: 500 },
+            }),
+            {}
+          ),
         }}
         centerComponent={
           <View bg="purplePrimary" borderRadius={'xl'} height={25} width={25} />

--- a/example/src/screens/Playground/Playground.tsx
+++ b/example/src/screens/Playground/Playground.tsx
@@ -138,8 +138,8 @@ const Playground = () => {
             value={numberOfPoints}
           />
           <Switch
-            leftLabel="Parallel Animation"
-            rightLabel="Sequential Animation"
+            leftLabel="Sequential Animation"
+            rightLabel="Parallel Animation"
             value={isParallelAnimation}
             onValueChange={setIsParallelAnimation}
           />

--- a/example/src/screens/RadialMenu/RadialMenu.tsx
+++ b/example/src/screens/RadialMenu/RadialMenu.tsx
@@ -64,10 +64,10 @@ const RadialMenu = () => {
         }}
         animationProps={{
           animationCombinationType: AnimationCombinationType.PARALLEL,
-          animationConfigs: [
-            { config: { duration: 500 }, type: AnimationType.LINEAR },
-            { config: { duration: 500 }, type: AnimationType.OPACITY },
-          ],
+          animationConfigs: {
+            [AnimationType.LINEAR]: { duration: 500 },
+            [AnimationType.OPACITY]: { duration: 500 },
+          },
         }}
         radius={100}
         ref={circleLayoutRef}

--- a/example/src/screens/index.ts
+++ b/example/src/screens/index.ts
@@ -1,3 +1,4 @@
 export { default as Home } from './Home/Home';
 export { default as Playground } from './Playground/Playground';
 export { default as RadialMenu } from './RadialMenu/RadialMenu';
+export { default as NestedRingMenu } from './NestedRingMenu/NestedRingMenu';

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,12 @@
+import { Easing } from 'react-native';
+
+// `Easing.ease`/`Easing.bezier` lazily `require('./bezier')` on first
+// invocation and cache the curve in a module-level variable. Animated.timing
+// schedules its update loop on real timers; if a stray callback fires after
+// Jest tears the test environment down, that lazy `require` resolves against
+// a registry that no longer exists and crashes the worker with
+// `_bezier is not a function`. Invoking them once here, while the
+// environment is intact, warms the cache so any later (even post-teardown)
+// invocation reuses it instead of re-requiring.
+Easing.ease(0);
+Easing.bezier(0.42, 0, 1, 1)(0);

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "typescript-eslint": "^8.60.0"
   },
   "peerDependencies": {
-    "react": "*",
+    "react": ">=19",
     "react-native": "*",
     "react-native-svg": "^15.15.5"
   },

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react": "19.2.6",
     "react-native": "0.85.3",
     "react-native-builder-bob": "^0.41.0",
+    "react-native-svg": "^15.15.5",
     "release-it": "^20.0.1",
     "turbo": "^2.9.15",
     "typescript": "^6.0.3",
@@ -95,7 +96,8 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-svg": "^15.15.5"
   },
   "packageManager": "pnpm@10.33.0",
   "react-native-builder-bob": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "!**/.*"
   ],
   "scripts": {
-    "test": "jest --forceExit",
+    "test": "jest",
     "typecheck": "tsc",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "prepare": "bob build",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "react-native": "*",
     "react-native-svg": "^15.15.5"
   },
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.5.2",
   "react-native-builder-bob": {
     "source": "src",
     "output": "lib",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "!**/.*"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest --forceExit",
     "typecheck": "tsc",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "prepare": "bob build",
@@ -120,6 +120,9 @@
   },
   "jest": {
     "preset": "@react-native/jest-preset",
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest.setup.ts"
+    ],
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",
       "<rootDir>/lib/"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       react-native-builder-bob:
         specifier: ^0.41.0
         version: 0.41.0
+      react-native-svg:
+        specifier: ^15.15.5
+        version: 15.15.5(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       release-it:
         specifier: ^20.0.1
         version: 20.0.1(@types/node@25.9.1)
@@ -2250,6 +2253,9 @@ packages:
   birecord@0.1.1:
     resolution: {integrity: sha512-VUpsf/qykW0heRlC8LooCq28Kxn3mAqKohhDG/49rrsQ1dT1CXyj/pgXS+5BSRzFTR/3DyIBOqQOrGyZOh71Aw==}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   bplist-creator@0.1.0:
     resolution: {integrity: sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==}
 
@@ -2559,6 +2565,17 @@ packages:
   css-in-js-utils@3.1.0:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-tree@1.1.3:
+    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
+    engines: {node: '>=8.0.0'}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2693,6 +2710,19 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
@@ -2731,6 +2761,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -4180,6 +4214,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdn-data@2.0.14:
+    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
@@ -4416,6 +4453,9 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
@@ -4787,6 +4827,12 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '>=0.82.0'
+
+  react-native-svg@15.15.5:
+    resolution: {integrity: sha512-L4go5jA+GWutdJ/JucuN20cjAbMg1HmMtAP+wZ+3JLCf6Jd0bhXQHxciRP/AQm/FlrIEZwkMcHNZP+FXAiic0w==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   react-native-web@0.21.2:
     resolution: {integrity: sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==}
@@ -8498,6 +8544,8 @@ snapshots:
 
   birecord@0.1.1: {}
 
+  boolbase@1.0.0: {}
+
   bplist-creator@0.1.0:
     dependencies:
       stream-buffers: 2.2.0
@@ -8846,6 +8894,21 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-tree@1.1.3:
+    dependencies:
+      mdn-data: 2.0.14
+      source-map: 0.6.1
+
+  css-what@6.2.2: {}
+
   csstype@3.2.3: {}
 
   data-uri-to-buffer@7.0.0: {}
@@ -8956,6 +9019,24 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
@@ -8985,6 +9066,8 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  entities@4.5.0: {}
 
   env-paths@2.2.1: {}
 
@@ -10760,6 +10843,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdn-data@2.0.14: {}
+
   memoize-one@5.2.1: {}
 
   memoize-one@6.0.0: {}
@@ -11071,6 +11156,10 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   nullthrows@1.1.1: {}
 
@@ -11495,6 +11584,13 @@ snapshots:
       react-freeze: 1.0.4(react@19.2.3)
       react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@types/react@19.2.15)(react@19.2.3)
       warn-once: 0.1.1
+
+  react-native-svg@15.15.5(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6):
+    dependencies:
+      css-select: 5.2.2
+      css-tree: 1.1.3
+      react: 19.2.6
+      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6)
 
   react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/src/Bg.tsx
+++ b/src/Bg.tsx
@@ -1,0 +1,131 @@
+import Svg, { Defs, Mask, Path } from 'react-native-svg';
+import type { BgConfig, Layout } from './types';
+import { Animated } from 'react-native';
+import { use, useEffect, useMemo } from 'react';
+import { useAnimatedSectorPath, useCombinedAnimation } from './hooks';
+import { CircleLayoutContext } from './CircleLayoutContext';
+
+const AnimatedSvg = Animated.createAnimatedComponent(Svg);
+const AnimatedPath = Animated.createAnimatedComponent(Path);
+
+export const Bg = ({
+  index,
+  radius,
+  minComponentLayout,
+  centerComponentLayout,
+  isVisible = true,
+  color = '#3d19e0',
+  strokeColor,
+  strokeWidth = 1,
+  outerRadius,
+  innerRadius = 0,
+}: {
+  index: number;
+  radius: number;
+  minComponentLayout: Layout;
+  centerComponentLayout: Layout;
+  isVisible?: boolean;
+} & BgConfig) => {
+  const { startAngle, sectorAngle } = use(CircleLayoutContext);
+  const { startAngleInRadians, endAngleInRadians } = useMemo(() => {
+    const angle = startAngle + index * sectorAngle;
+    return {
+      startAngleInRadians: angle - sectorAngle / 2,
+      endAngleInRadians: angle + sectorAngle / 2,
+    };
+  }, [startAngle, sectorAngle, index]);
+
+  const { size, center } = useMemo(() => {
+    const padding = 0;
+    const diameter = (outerRadius ?? radius) * 2;
+    const width =
+      diameter +
+      minComponentLayout.width -
+      centerComponentLayout.width / 2 +
+      padding;
+    const height =
+      diameter +
+      minComponentLayout.height -
+      centerComponentLayout.height / 2 +
+      padding;
+    const s = Math.max(width, height);
+
+    return { size: s, center: { x: s / 2, y: s / 2 } };
+  }, [
+    outerRadius,
+    radius,
+    minComponentLayout.width,
+    minComponentLayout.height,
+    centerComponentLayout.width,
+    centerComponentLayout.height,
+  ]);
+
+  const {
+    hideComponent,
+    opacityValue,
+    radiansValue,
+    radiusValue,
+    showComponent,
+  } = useCombinedAnimation({
+    index,
+    radians: endAngleInRadians,
+    startAngle: startAngleInRadians,
+    radius: size / 2,
+  });
+
+  useEffect(() => {
+    if (isVisible) {
+      showComponent();
+    } else {
+      hideComponent();
+    }
+  }, [hideComponent, isVisible, showComponent]);
+
+  const path = useAnimatedSectorPath({
+    radius: radiusValue,
+    startAngle: startAngleInRadians,
+    endAngle: radiansValue,
+    center,
+  });
+
+  return (
+    <AnimatedSvg
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        transform: [
+          { translateX: (-size + centerComponentLayout.width) / 2 },
+          { translateY: (-size + centerComponentLayout.height) / 2 },
+        ],
+      }}
+      width={size}
+      height={size}
+    >
+      <Defs>
+        <Mask id={`mask_${index}`}>
+          <AnimatedPath d={path} fill="white" />
+          <AnimatedPath
+            d={useAnimatedSectorPath({
+              radius: innerRadius,
+              startAngle: startAngleInRadians,
+              endAngle: endAngleInRadians,
+              center,
+            })}
+            fill="black"
+            stroke="black"
+          />
+        </Mask>
+      </Defs>
+      <AnimatedPath
+        mask={`url(#mask_${index})`}
+        d={path}
+        fill={color}
+        stroke={strokeColor ?? color}
+        strokeOpacity={0.5}
+        strokeWidth={strokeWidth}
+        opacity={opacityValue}
+      />
+    </AnimatedSvg>
+  );
+};

--- a/src/Bg.tsx
+++ b/src/Bg.tsx
@@ -71,6 +71,7 @@ export const Bg = ({
     radians: endAngleInRadians,
     startAngle: startAngleInRadians,
     radius: size / 2,
+    useNativeDriver: false,
   });
 
   useLayoutEffect(() => {

--- a/src/Bg.tsx
+++ b/src/Bg.tsx
@@ -1,7 +1,7 @@
 import Svg, { Defs, Mask, Path } from 'react-native-svg';
 import type { BgConfig, Layout } from './types';
 import { Animated } from 'react-native';
-import { use, useEffect, useMemo } from 'react';
+import { use, useLayoutEffect, useMemo } from 'react';
 import { useAnimatedSectorPath, useCombinedAnimation } from './hooks';
 import { CircleLayoutContext } from './CircleLayoutContext';
 
@@ -73,7 +73,7 @@ export const Bg = ({
     radius: size / 2,
   });
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (isVisible) {
       showComponent();
     } else {

--- a/src/CircleLayout.tsx
+++ b/src/CircleLayout.tsx
@@ -1,10 +1,9 @@
-import React, { useMemo } from 'react';
-import { Animated, View } from 'react-native';
+import React from 'react';
 
-import CircleLayoutArray from './CircleLayoutArray';
-import type { CircleLayoutProps, CircleLayoutRef, Layout } from './types';
-import { validateProps } from './utils/validation';
+import { CircleLayoutContent } from './CircleLayoutContent';
 import { CircleLayoutProvider } from './CircleLayoutProvider';
+import type { CircleLayoutProps, CircleLayoutRef } from './types';
+import { validateProps } from './utils';
 
 /**
  * A component that places a list of components in a circular layout.
@@ -26,7 +25,7 @@ import { CircleLayoutProvider } from './CircleLayoutProvider';
 export const CircleLayout = ({
   ref,
   ...circleLayoutProps
-}: CircleLayoutProps & { ref: React.Ref<CircleLayoutRef> }) => {
+}: CircleLayoutProps & { ref?: React.Ref<CircleLayoutRef> }) => {
   const {
     components,
     radius,
@@ -38,65 +37,23 @@ export const CircleLayout = ({
     animationProps,
   } = validateProps(circleLayoutProps);
 
-  const isGreaterThanHalfCircle = useMemo(
-    () => sweepAngle >= Math.PI,
-    [sweepAngle]
-  );
-
-  const [minComponentLayout, setMinComponentLayout] = React.useState<Layout>({
-    height: 0,
-    width: 0,
-  });
-  const { minHeight, minWidth } = useMemo(() => {
-    const defaultMinDimension = isGreaterThanHalfCircle ? 2 * radius : radius;
-    return {
-      minHeight: defaultMinDimension + minComponentLayout.height,
-      minWidth: defaultMinDimension + minComponentLayout.width,
-    };
-  }, [minComponentLayout, radius, isGreaterThanHalfCircle]);
-
-  const [centerComponentLayout, setCenterComponentLayout] =
-    React.useState<Layout>({ width: 0, height: 0 });
-
   return (
     <CircleLayoutProvider
-      componentLength={components.length}
+      sweepAngle={sweepAngle}
       radius={radius}
       startAngle={startAngle}
-      sweepAngle={sweepAngle}
+      componentLength={components.length}
       animationProps={animationProps}
     >
-      <View
-        style={[
-          {
-            minHeight,
-            minWidth,
-            justifyContent: sweepAngle >= Math.PI ? 'center' : 'flex-end',
-            alignItems: 'center',
-          },
-          containerStyle,
-        ]}
-      >
-        <View>
-          {/* The list of components to be shown in the circle. */}
-          <CircleLayoutArray
-            ref={ref}
-            components={components}
-            sweepAngle={sweepAngle}
-            setMinComponentLayout={setMinComponentLayout}
-            centerComponentLayout={centerComponentLayout}
-          />
-          <Animated.View
-            style={[centerComponentContainerStyle]}
-            onLayout={(event) => {
-              const layout = event.nativeEvent.layout;
-              setCenterComponentLayout(layout);
-            }}
-          >
-            {centerComponent}
-          </Animated.View>
-        </View>
-      </View>
+      <CircleLayoutContent
+        ref={ref}
+        radius={radius}
+        components={components}
+        centerComponent={centerComponent}
+        containerStyle={containerStyle}
+        centerComponentContainerStyle={centerComponentContainerStyle}
+        sweepAngle={sweepAngle}
+      />
     </CircleLayoutProvider>
   );
 };

--- a/src/CircleLayout.tsx
+++ b/src/CircleLayout.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { Animated, View } from 'react-native';
 
+import CircleLayoutArray from './CircleLayoutArray';
 import { CircleLayoutContext } from './CircleLayoutContext';
 import type {
   CircleLayoutContextType,
@@ -8,44 +9,7 @@ import type {
   CircleLayoutRef,
   Layout,
 } from './types';
-import CircleLayoutArray from './CircleLayoutArray';
-
-/**
- * Validates the props passed to the CircleLayout component and
- * returns the validated props. If any of the props are invalid, an error is thrown.
- * @param props The properties passed to the component
- * @returns The validated properties
- */
-export function validateProps(props: CircleLayoutProps): CircleLayoutProps & {
-  sweepAngle: number;
-  startAngle: number;
-} {
-  const errors: string[] = [];
-  if (props.components.length < 2) {
-    errors.push('At least two components need to be passed to CircleLayout');
-  }
-  if (props.radius <= 0) {
-    errors.push('Radius needs to be greater than 0');
-  }
-
-  if (props.sweepAngle === 0) {
-    errors.push('Sweep angle cannot be 0');
-  }
-
-  if (errors.length > 0) {
-    throw new Error(errors.join('\n'));
-  }
-
-  return {
-    ...props,
-    sweepAngle: props.sweepAngle
-      ? props.sweepAngle % (2 * Math.PI) === 0
-        ? 2 * Math.PI
-        : props.sweepAngle % (2 * Math.PI)
-      : 2 * Math.PI,
-    startAngle: (props.startAngle ?? 0) % (2 * Math.PI),
-  };
-}
+import { validateProps } from './utils/validation';
 
 /**
  * A component that places a list of components in a circular layout.

--- a/src/CircleLayout.tsx
+++ b/src/CircleLayout.tsx
@@ -35,6 +35,7 @@ export const CircleLayout = ({
     containerStyle,
     centerComponentContainerStyle,
     animationProps,
+    bgConfig,
   } = validateProps(circleLayoutProps);
 
   return (
@@ -53,6 +54,7 @@ export const CircleLayout = ({
         containerStyle={containerStyle}
         centerComponentContainerStyle={centerComponentContainerStyle}
         sweepAngle={sweepAngle}
+        bgConfig={bgConfig}
       />
     </CircleLayoutProvider>
   );

--- a/src/CircleLayout.tsx
+++ b/src/CircleLayout.tsx
@@ -2,14 +2,9 @@ import React, { useMemo } from 'react';
 import { Animated, View } from 'react-native';
 
 import CircleLayoutArray from './CircleLayoutArray';
-import { CircleLayoutContext } from './CircleLayoutContext';
-import type {
-  CircleLayoutContextType,
-  CircleLayoutProps,
-  CircleLayoutRef,
-  Layout,
-} from './types';
+import type { CircleLayoutProps, CircleLayoutRef, Layout } from './types';
 import { validateProps } from './utils/validation';
+import { CircleLayoutProvider } from './CircleLayoutProvider';
 
 /**
  * A component that places a list of components in a circular layout.
@@ -43,12 +38,10 @@ export const CircleLayout = ({
     animationProps,
   } = validateProps(circleLayoutProps);
 
-  const { isCompleteCircle, isGreaterThanHalfCircle } = useMemo(() => {
-    return {
-      isCompleteCircle: Math.abs(sweepAngle - 2 * Math.PI) < 0.001,
-      isGreaterThanHalfCircle: sweepAngle >= Math.PI,
-    };
-  }, [sweepAngle]);
+  const isGreaterThanHalfCircle = useMemo(
+    () => sweepAngle >= Math.PI,
+    [sweepAngle]
+  );
 
   const [minComponentLayout, setMinComponentLayout] = React.useState<Layout>({
     height: 0,
@@ -65,22 +58,14 @@ export const CircleLayout = ({
   const [centerComponentLayout, setCenterComponentLayout] =
     React.useState<Layout>({ width: 0, height: 0 });
 
-  // The total number of parts to divide the circle into
-  const totalParts = React.useMemo(
-    () => (isCompleteCircle ? components.length : components.length - 1),
-    [components.length, isCompleteCircle]
-  );
-
-  /**
-   * The value passed to the context of the circle layout.
-   */
-  const contextValue: CircleLayoutContextType = React.useMemo(
-    () => ({ totalParts, radius, startAngle, animationProps }),
-    [animationProps, radius, startAngle, totalParts]
-  );
-
   return (
-    <CircleLayoutContext value={contextValue}>
+    <CircleLayoutProvider
+      componentLength={components.length}
+      radius={radius}
+      startAngle={startAngle}
+      sweepAngle={sweepAngle}
+      animationProps={animationProps}
+    >
       <View
         style={[
           {
@@ -112,6 +97,6 @@ export const CircleLayout = ({
           </Animated.View>
         </View>
       </View>
-    </CircleLayoutContext>
+    </CircleLayoutProvider>
   );
 };

--- a/src/CircleLayoutArray.tsx
+++ b/src/CircleLayoutArray.tsx
@@ -78,7 +78,7 @@ function CircleLayoutArray({
     setMinComponentLayout(minLayout);
   }, [componentLayouts, setMinComponentLayout, sweepAngle]);
 
-  const { startAngle, totalParts } = use(CircleLayoutContext);
+  const { startAngle, totalParts, sectorAngle } = use(CircleLayoutContext);
 
   /**
    * The instance value that is exposed to parent components when using ref.
@@ -111,8 +111,7 @@ function CircleLayoutArray({
   }, [startAngle, sweepAngle, totalParts, isComponentsVisible]);
 
   return components.map((component, index) => {
-    const angle =
-      (startAngle + sweepAngle * (index / totalParts)) % (2 * Math.PI);
+    const angle = (startAngle + sectorAngle * index) % (2 * Math.PI);
     return (
       <CircleLayoutComponent
         component={component}

--- a/src/CircleLayoutComponent.tsx
+++ b/src/CircleLayoutComponent.tsx
@@ -4,7 +4,7 @@ import { Animated } from 'react-native';
 import { useCombinedAnimation } from './hooks';
 import { circleComponentStyles } from './styles';
 import type { ComponentProps, ComponentRef, Layout } from './types';
-import { pointOnCircle } from './utils';
+import { pointOnCircle, pointOnCircleAnimated } from './utils';
 
 /**
  * A component that positions one component in the circle layout.
@@ -43,10 +43,10 @@ export const CircleLayoutComponent = ({
 
   // The position of the component.
   // This is animated if either linear or circular animation config is passed.
-  const position = pointOnCircle({
-    radians: radiansValue,
-    radius: radiusValue,
-  });
+  const position =
+    typeof radiansValue === 'number' && typeof radiusValue === 'number'
+      ? pointOnCircle({ radians: radiansValue, radius: radiusValue })
+      : pointOnCircleAnimated({ radians: radiansValue, radius: radiusValue });
 
   /**
    * The instance value that is exposed to parent components when using ref.

--- a/src/CircleLayoutComponent.tsx
+++ b/src/CircleLayoutComponent.tsx
@@ -67,7 +67,7 @@ export const CircleLayoutComponent = ({
               translateX: Animated.multiply(
                 Animated.subtract(
                   position.x,
-                  layout.width / 2 - centerComponentLayout.width / 2
+                  (layout.width - centerComponentLayout.width) / 2
                 ),
                 -1
               ),
@@ -77,7 +77,7 @@ export const CircleLayoutComponent = ({
               translateY: Animated.multiply(
                 Animated.subtract(
                   position.y,
-                  layout.height / 2 - centerComponentLayout.height / 2
+                  (layout.height - centerComponentLayout.height) / 2
                 ),
                 -1
               ),

--- a/src/CircleLayoutContent.tsx
+++ b/src/CircleLayoutContent.tsx
@@ -37,8 +37,8 @@ export function CircleLayoutContent({
   radius: number;
   components: React.ReactNode[];
   centerComponent?: React.ReactNode;
-  containerStyle?: StyleProp<ViewStyle> | undefined | undefined;
-  centerComponentContainerStyle?: StyleProp<ViewStyle> | undefined | undefined;
+  containerStyle?: StyleProp<ViewStyle> | undefined;
+  centerComponentContainerStyle?: StyleProp<ViewStyle> | undefined;
   sweepAngle: number;
   bgConfig?: BgConfig;
 } & React.RefAttributes<CircleLayoutRef>) {

--- a/src/CircleLayoutContent.tsx
+++ b/src/CircleLayoutContent.tsx
@@ -1,0 +1,88 @@
+import { useMemo } from 'react';
+import { type StyleProp, type ViewStyle, Animated, View } from 'react-native';
+import CircleLayoutArray from './CircleLayoutArray';
+import type { CircleLayoutRef, Layout } from './types';
+import React from 'react';
+
+/**
+ * The content of the CircleLayout component. This is separated from the main
+ * CircleLayout component to avoid unnecessary re-renders of the entire component
+ * when the layout of the components is calculated.
+ * @param props The properties passed to the component
+ * @param props.radius The radius of the circle on which the components will be placed.
+ * @param props.components The list of components to be placed in the circle layout.
+ * @param props.centerComponent The component to be placed at the center of the circle layout.
+ * @param props.containerStyle The styling of the entire component's container.
+ * @param props.centerComponentContainerStyle The styling of the center component's container.
+ * @param props.sweepAngle The distance in radians to be covered from the starting point. The value needs to be in radians.
+ * @param props.ref The ref that is used to expose the show and hide function of the
+ * component to parent components.
+ * @returns The content of the CircleLayout component which contains the
+ * background and the components to be placed in the circle layout.
+ * @see CircleLayout
+ */
+export function CircleLayoutContent({
+  radius,
+  components,
+  centerComponent,
+  containerStyle,
+  centerComponentContainerStyle,
+  sweepAngle,
+  ref,
+}: {
+  radius: number;
+  components: React.ReactNode[];
+  centerComponent?: React.ReactNode;
+  containerStyle?: StyleProp<ViewStyle> | undefined | undefined;
+  centerComponentContainerStyle?: StyleProp<ViewStyle> | undefined | undefined;
+  sweepAngle: number;
+} & React.RefAttributes<CircleLayoutRef>) {
+  const [minComponentLayout, setMinComponentLayout] = React.useState<Layout>({
+    height: 0,
+    width: 0,
+  });
+  const { minHeight, minWidth } = useMemo(() => {
+    const defaultMinDimension = sweepAngle >= Math.PI ? 2 * radius : radius;
+    return {
+      minHeight: defaultMinDimension + minComponentLayout.height,
+      minWidth: defaultMinDimension + minComponentLayout.width,
+    };
+  }, [minComponentLayout, radius, sweepAngle]);
+
+  const [centerComponentLayout, setCenterComponentLayout] =
+    React.useState<Layout>({ width: 0, height: 0 });
+
+  return (
+    <View
+      style={[
+        {
+          minHeight,
+          minWidth,
+          justifyContent: sweepAngle >= Math.PI ? 'center' : 'flex-end',
+          alignItems: 'center',
+        },
+        containerStyle,
+      ]}
+    >
+      <View>
+        {/* The list of components to be shown in the circle. */}
+        <CircleLayoutArray
+          ref={ref}
+          components={components}
+          sweepAngle={sweepAngle}
+          setMinComponentLayout={setMinComponentLayout}
+          centerComponentLayout={centerComponentLayout}
+        />
+        <Animated.View
+          style={[centerComponentContainerStyle]}
+          onLayout={(event) => {
+            const layout = event.nativeEvent.layout;
+            setCenterComponentLayout(layout);
+          }}
+        >
+          {centerComponent}
+        </Animated.View>
+      </View>
+    </View>
+  );
+}

--- a/src/CircleLayoutContent.tsx
+++ b/src/CircleLayoutContent.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react';
+import { useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { type StyleProp, type ViewStyle, Animated, View } from 'react-native';
 import CircleLayoutArray from './CircleLayoutArray';
-import type { CircleLayoutRef, Layout } from './types';
+import type { BgConfig, CircleLayoutRef, Layout } from './types';
 import React from 'react';
+import { Bg } from './Bg';
 
 /**
  * The content of the CircleLayout component. This is separated from the main
@@ -14,7 +15,9 @@ import React from 'react';
  * @param props.centerComponent The component to be placed at the center of the circle layout.
  * @param props.containerStyle The styling of the entire component's container.
  * @param props.centerComponentContainerStyle The styling of the center component's container.
- * @param props.sweepAngle The distance in radians to be covered from the starting point. The value needs to be in radians.
+ * @param props.bgConfig The configuration for the background of the circle layout.
+ * @param props.sweepAngle The distance in radians to be covered from the starting point. The
+ * value needs to be in radians.
  * @param props.ref The ref that is used to expose the show and hide function of the
  * component to parent components.
  * @returns The content of the CircleLayout component which contains the
@@ -28,6 +31,7 @@ export function CircleLayoutContent({
   containerStyle,
   centerComponentContainerStyle,
   sweepAngle,
+  bgConfig,
   ref,
 }: {
   radius: number;
@@ -36,7 +40,11 @@ export function CircleLayoutContent({
   containerStyle?: StyleProp<ViewStyle> | undefined | undefined;
   centerComponentContainerStyle?: StyleProp<ViewStyle> | undefined | undefined;
   sweepAngle: number;
+  bgConfig?: BgConfig;
 } & React.RefAttributes<CircleLayoutRef>) {
+  const componentLayoutArrayRef = useRef<CircleLayoutRef>(null);
+  const [componentVisible, setComponentVisible] = useState(false);
+
   const [minComponentLayout, setMinComponentLayout] = React.useState<Layout>({
     height: 0,
     width: 0,
@@ -52,6 +60,24 @@ export function CircleLayoutContent({
   const [centerComponentLayout, setCenterComponentLayout] =
     React.useState<Layout>({ width: 0, height: 0 });
 
+  /**
+   * The instance value that is exposed to parent components when using ref.
+   */
+  useImperativeHandle(
+    ref,
+    () => ({
+      hideComponents: () => {
+        componentLayoutArrayRef.current?.hideComponents();
+        setComponentVisible(false);
+      },
+      showComponents: () => {
+        componentLayoutArrayRef.current?.showComponents();
+        setComponentVisible(true);
+      },
+    }),
+    [setComponentVisible]
+  );
+
   return (
     <View
       style={[
@@ -65,9 +91,21 @@ export function CircleLayoutContent({
       ]}
     >
       <View>
+        {bgConfig &&
+          components.map((_, index) => (
+            <Bg
+              key={index}
+              index={index}
+              minComponentLayout={minComponentLayout}
+              centerComponentLayout={centerComponentLayout}
+              radius={radius}
+              isVisible={componentVisible}
+              {...bgConfig}
+            />
+          ))}
         {/* The list of components to be shown in the circle. */}
         <CircleLayoutArray
-          ref={ref}
+          ref={componentLayoutArrayRef}
           components={components}
           sweepAngle={sweepAngle}
           setMinComponentLayout={setMinComponentLayout}

--- a/src/CircleLayoutContext.tsx
+++ b/src/CircleLayoutContext.tsx
@@ -10,5 +10,6 @@ export const CircleLayoutContext = React.createContext<CircleLayoutContextType>(
     totalParts: 0,
     radius: 0,
     startAngle: 0,
+    sectorAngle: 0,
   }
 );

--- a/src/CircleLayoutProvider.tsx
+++ b/src/CircleLayoutProvider.tsx
@@ -56,8 +56,9 @@ export const CircleLayoutProvider = ({
       radius,
       startAngle,
       animationProps,
+      sectorAngle: sweepAngle / totalParts,
     }),
-    [animationProps, radius, startAngle, totalParts]
+    [animationProps, radius, startAngle, sweepAngle, totalParts]
   );
 
   return (

--- a/src/CircleLayoutProvider.tsx
+++ b/src/CircleLayoutProvider.tsx
@@ -1,0 +1,66 @@
+import React, { useMemo } from 'react';
+
+import { CircleLayoutContext } from './CircleLayoutContext';
+import type { CircleLayoutContextType, CircleLayoutProps } from './types';
+
+type CircleLayoutProviderProps = Required<
+  Omit<
+    CircleLayoutProps,
+    | 'centerComponent'
+    | 'containerStyle'
+    | 'centerComponentContainerStyle'
+    | 'components'
+    | 'animationProps'
+  > & {
+    componentLength: number;
+  }
+> &
+  Pick<CircleLayoutProps, 'animationProps'>;
+/**
+ * A component that places a list of components in a circular layout.
+ * @param props The properties passed to the component
+ * @param props.radius The radius of the circle on which the components will be placed.
+ * @param props.sweepAngle The distance in radians to be covered from the starting point. The value needs to be in radians.
+ * @param props.startAngle The angle at which the first component will be placed. The value needs to be in radians.
+ * @param props.componentLength The number of components to be placed in the circle layout.
+ * @param props.children The child components to be rendered inside the circle layout.
+ * @param props.animationProps The props for the animation.
+ * @see AnimationProps
+ * @returns A component that places the passed components in a circular view.
+ */
+export const CircleLayoutProvider = ({
+  sweepAngle,
+  radius,
+  startAngle,
+  componentLength,
+  children,
+  animationProps,
+}: React.PropsWithChildren<CircleLayoutProviderProps>) => {
+  const isCompleteCircle = useMemo(
+    () => Math.abs(sweepAngle - 2 * Math.PI) < 0.001,
+    [sweepAngle]
+  );
+
+  // The total number of parts to divide the circle into
+  const totalParts = React.useMemo(
+    () => (isCompleteCircle ? componentLength : componentLength - 1),
+    [componentLength, isCompleteCircle]
+  );
+
+  /**
+   * The value passed to the context of the circle layout.
+   */
+  const contextValue: CircleLayoutContextType = React.useMemo(
+    () => ({
+      totalParts,
+      radius,
+      startAngle,
+      animationProps,
+    }),
+    [animationProps, radius, startAngle, totalParts]
+  );
+
+  return (
+    <CircleLayoutContext value={contextValue}>{children}</CircleLayoutContext>
+  );
+};

--- a/src/CircleLayoutProvider.tsx
+++ b/src/CircleLayoutProvider.tsx
@@ -11,6 +11,7 @@ type CircleLayoutProviderProps = Required<
     | 'centerComponentContainerStyle'
     | 'components'
     | 'animationProps'
+    | 'bgConfig'
   > & {
     componentLength: number;
   }

--- a/src/__tests__/CircleLayout.test.tsx
+++ b/src/__tests__/CircleLayout.test.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 import { Text } from 'react-native';
+import Svg from 'react-native-svg';
 import { render, act, renderHook } from '@testing-library/react-native';
 
 import { CircleLayout } from '../CircleLayout';
@@ -209,6 +210,59 @@ describe('CircleLayout', () => {
           />
         )
       ).not.toThrow();
+    });
+  });
+
+  describe('background (bgConfig)', () => {
+    it('does not render a background when bgConfig is not provided', () => {
+      const { UNSAFE_queryAllByType } = render(
+        <CircleLayout components={makeComponents(2)} radius={100} ref={null} />
+      );
+      expect(UNSAFE_queryAllByType(Svg)).toHaveLength(0);
+    });
+
+    it('renders one background sector per component when bgConfig is provided', () => {
+      const { UNSAFE_queryAllByType } = render(
+        <CircleLayout
+          components={makeComponents(3)}
+          radius={100}
+          bgConfig={{ color: 'red' }}
+          ref={null}
+        />
+      );
+      expect(UNSAFE_queryAllByType(Svg)).toHaveLength(3);
+    });
+
+    it('renders without throwing when innerRadius and outerRadius are set', () => {
+      expect(() =>
+        render(
+          <CircleLayout
+            components={makeComponents(3)}
+            radius={100}
+            bgConfig={{ innerRadius: 20, outerRadius: 150 }}
+            ref={null}
+          />
+        )
+      ).not.toThrow();
+    });
+
+    it('shows the background when showComponents is called via ref', () => {
+      const { result } = renderHook(() => useRef<CircleLayoutRef>(null));
+      const ref = result.current;
+      expect(() => {
+        render(
+          <CircleLayout
+            components={makeComponents(2)}
+            radius={100}
+            bgConfig={{ color: 'blue' }}
+            ref={ref}
+          />
+        );
+        act(() => {
+          ref.current?.showComponents();
+          ref.current?.hideComponents();
+        });
+      }).not.toThrow();
     });
   });
 

--- a/src/__tests__/CircleLayout.test.tsx
+++ b/src/__tests__/CircleLayout.test.tsx
@@ -2,8 +2,9 @@ import { useRef } from 'react';
 import { Text } from 'react-native';
 import { render, act, renderHook } from '@testing-library/react-native';
 
-import { CircleLayout, validateProps } from '../CircleLayout';
+import { CircleLayout } from '../CircleLayout';
 import type { CircleLayoutRef } from '../types';
+import { validateProps } from '../utils';
 
 const makeComponents = (n: number) =>
   Array.from({ length: n }, (_, i) => <Text key={i}>Item {i}</Text>);

--- a/src/__tests__/CircleLayoutArray.test.tsx
+++ b/src/__tests__/CircleLayoutArray.test.tsx
@@ -14,6 +14,7 @@ const baseContext: CircleLayoutContextType = {
   totalParts: 2,
   radius: 100,
   startAngle: 0,
+  sectorAngle: Math.PI,
 };
 
 const noopSetLayout = () => {};

--- a/src/__tests__/CircleLayoutComponent.test.tsx
+++ b/src/__tests__/CircleLayoutComponent.test.tsx
@@ -149,9 +149,9 @@ describe('CircleLayoutComponent', () => {
       const ctx: CircleLayoutContextType = {
         ...baseContext,
         animationProps: {
-          animationConfigs: [
-            { type: AnimationType.OPACITY, config: { duration: 300 } },
-          ],
+          animationConfigs: {
+            [AnimationType.OPACITY]: { duration: 300 },
+          },
           animationCombinationType: AnimationCombinationType.PARALLEL,
         },
       };
@@ -162,9 +162,9 @@ describe('CircleLayoutComponent', () => {
       const ctx: CircleLayoutContextType = {
         ...baseContext,
         animationProps: {
-          animationConfigs: [
-            { type: AnimationType.LINEAR, config: { duration: 300 } },
-          ],
+          animationConfigs: {
+            [AnimationType.LINEAR]: { duration: 300 },
+          },
           animationCombinationType: AnimationCombinationType.PARALLEL,
         },
       };
@@ -175,9 +175,9 @@ describe('CircleLayoutComponent', () => {
       const ctx: CircleLayoutContextType = {
         ...baseContext,
         animationProps: {
-          animationConfigs: [
-            { type: AnimationType.CIRCULAR, config: { duration: 300 } },
-          ],
+          animationConfigs: {
+            [AnimationType.CIRCULAR]: { duration: 300 },
+          },
           animationCombinationType: AnimationCombinationType.PARALLEL,
         },
       };
@@ -188,11 +188,11 @@ describe('CircleLayoutComponent', () => {
       const ctx: CircleLayoutContextType = {
         ...baseContext,
         animationProps: {
-          animationConfigs: [
-            { type: AnimationType.OPACITY, config: { duration: 300 } },
-            { type: AnimationType.LINEAR, config: { duration: 300 } },
-            { type: AnimationType.CIRCULAR, config: { duration: 300 } },
-          ],
+          animationConfigs: {
+            [AnimationType.OPACITY]: { duration: 300 },
+            [AnimationType.LINEAR]: { duration: 300 },
+            [AnimationType.CIRCULAR]: { duration: 300 },
+          },
           animationCombinationType: AnimationCombinationType.SEQUENCE,
           animationGap: 50,
         },

--- a/src/__tests__/CircleLayoutComponent.test.tsx
+++ b/src/__tests__/CircleLayoutComponent.test.tsx
@@ -16,6 +16,7 @@ const baseContext: CircleLayoutContextType = {
   totalParts: 3,
   radius: 100,
   startAngle: 0,
+  sectorAngle: (2 * Math.PI) / 3,
 };
 
 const zeroCenterLayout: Layout = { width: 0, height: 0 };

--- a/src/__tests__/hooks/useAnimatedSectorPath.test.ts
+++ b/src/__tests__/hooks/useAnimatedSectorPath.test.ts
@@ -1,0 +1,108 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { Animated } from 'react-native';
+
+import { useAnimatedSectorPath } from '../../hooks/useAnimatedSectorPath';
+import { getSectorPath } from '../../utils/circle';
+
+const center = { x: 50, y: 50 };
+const startAngle = 0;
+
+describe('useAnimatedSectorPath', () => {
+  describe('static radius and endAngle', () => {
+    it('returns the same path as getSectorPath', () => {
+      const { result } = renderHook(() =>
+        useAnimatedSectorPath({
+          radius: 40,
+          startAngle,
+          endAngle: Math.PI / 2,
+          center,
+        })
+      );
+
+      expect(result.current).toBe(
+        getSectorPath({ radius: 40, startAngle, endAngle: Math.PI / 2, center })
+      );
+    });
+  });
+
+  describe('only radius animated', () => {
+    it('returns an animated interpolation node', () => {
+      const radius = new Animated.Value(40);
+      const { result } = renderHook(() =>
+        useAnimatedSectorPath({
+          radius,
+          startAngle,
+          endAngle: Math.PI / 2,
+          center,
+        })
+      );
+
+      expect(result.current?.constructor.name).toBe('AnimatedInterpolation');
+    });
+  });
+
+  describe('only endAngle animated', () => {
+    it('returns an animated interpolation node', () => {
+      const endAngle = new Animated.Value(0);
+      const { result } = renderHook(() =>
+        useAnimatedSectorPath({
+          radius: 40,
+          startAngle,
+          endAngle,
+          center,
+        })
+      );
+
+      expect(result.current?.constructor.name).toBe('AnimatedInterpolation');
+    });
+  });
+
+  describe('both radius and endAngle animated', () => {
+    it('starts as an empty string before any listener fires', () => {
+      const radius = new Animated.Value(40);
+      const endAngle = new Animated.Value(0);
+      const { result } = renderHook(() =>
+        useAnimatedSectorPath({ radius, startAngle, endAngle, center })
+      );
+
+      expect(result.current).toBe('');
+    });
+
+    it('recomputes the path from the latest radius and endAngle values', () => {
+      const radius = new Animated.Value(40);
+      const endAngle = new Animated.Value(0);
+      const { result } = renderHook(() =>
+        useAnimatedSectorPath({ radius, startAngle, endAngle, center })
+      );
+
+      act(() => {
+        radius.setValue(60);
+        endAngle.setValue(Math.PI / 2);
+      });
+
+      expect(result.current).toBe(
+        getSectorPath({
+          radius: 60,
+          startAngle,
+          endAngle: Math.PI / 2,
+          center,
+        })
+      );
+    });
+
+    it('removes listeners on unmount', () => {
+      const radius = new Animated.Value(40);
+      const endAngle = new Animated.Value(0);
+      const removeRadiusListener = jest.spyOn(radius, 'removeListener');
+      const removeEndAngleListener = jest.spyOn(endAngle, 'removeListener');
+
+      const { unmount } = renderHook(() =>
+        useAnimatedSectorPath({ radius, startAngle, endAngle, center })
+      );
+      unmount();
+
+      expect(removeRadiusListener).toHaveBeenCalledTimes(1);
+      expect(removeEndAngleListener).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/__tests__/hooks/useAnimation.test.ts
+++ b/src/__tests__/hooks/useAnimation.test.ts
@@ -30,6 +30,48 @@ const trackAnimatedValue = (v: Animated.Value, initialValue: number) => {
 };
 
 describe('useAnimation', () => {
+  describe('native driver configuration', () => {
+    it('uses native driver by default', () => {
+      const timingSpy = jest.spyOn(Animated, 'timing');
+
+      const { result } = renderHook(() => useAnimation(baseConfig));
+      result.current.entryAnimation();
+      result.current.exitAnimation();
+
+      const entryCallConfig = timingSpy.mock.calls[0]?.[1] as
+        | Animated.TimingAnimationConfig
+        | undefined;
+      const exitCallConfig = timingSpy.mock.calls[1]?.[1] as
+        | Animated.TimingAnimationConfig
+        | undefined;
+
+      expect(entryCallConfig?.useNativeDriver).toBe(true);
+      expect(exitCallConfig?.useNativeDriver).toBe(true);
+      timingSpy.mockRestore();
+    });
+
+    it('allows disabling native driver explicitly', () => {
+      const timingSpy = jest.spyOn(Animated, 'timing');
+
+      const { result } = renderHook(() =>
+        useAnimation({ ...baseConfig, useNativeDriver: false })
+      );
+      result.current.entryAnimation();
+      result.current.exitAnimation();
+
+      const entryCallConfig = timingSpy.mock.calls[0]?.[1] as
+        | Animated.TimingAnimationConfig
+        | undefined;
+      const exitCallConfig = timingSpy.mock.calls[1]?.[1] as
+        | Animated.TimingAnimationConfig
+        | undefined;
+
+      expect(entryCallConfig?.useNativeDriver).toBe(false);
+      expect(exitCallConfig?.useNativeDriver).toBe(false);
+      timingSpy.mockRestore();
+    });
+  });
+
   describe('initial state', () => {
     it('initializes Animated.Value at initialValue', () => {
       const { result } = renderHook(() => useAnimation(baseConfig));

--- a/src/__tests__/hooks/useAnimation.test.ts
+++ b/src/__tests__/hooks/useAnimation.test.ts
@@ -237,10 +237,16 @@ describe('useAnimation', () => {
           exitAnimationConfig: { duration: 0 },
         })
       );
+      const entry = result.current.entryAnimation();
+      const exit = result.current.exitAnimation();
       expect(() => {
-        result.current.entryAnimation().start();
-        result.current.exitAnimation().start();
+        entry.start();
+        exit.start();
       }).not.toThrow();
+      // duration: 0 still schedules a requestAnimationFrame tick — stop it so
+      // it doesn't fire (and pull in the bezier easing module) after teardown.
+      entry.stop();
+      exit.stop();
     });
 
     it('exitAnimationConfig defaults to entryAnimationConfig when omitted', () => {
@@ -251,11 +257,18 @@ describe('useAnimation', () => {
           entryAnimationConfig: { duration: 400 },
         })
       );
+      const entry = result.current.entryAnimation();
+      const exit = result.current.exitAnimation();
       // Both must be callable without throwing
       expect(() => {
-        result.current.entryAnimation().start();
-        result.current.exitAnimation().start();
+        entry.start();
+        exit.start();
       }).not.toThrow();
+      // Stop immediately — a real 400ms timing animation left running fires
+      // its easing callback after Jest tears down the environment, crashing
+      // the worker (`_bezier is not a function`).
+      entry.stop();
+      exit.stop();
     });
   });
 });

--- a/src/__tests__/hooks/useCombinedAnimation.test.tsx
+++ b/src/__tests__/hooks/useCombinedAnimation.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-native';
+import { act, renderHook } from '@testing-library/react-native';
 
 import { CircleLayoutContext } from '../../CircleLayoutContext';
 import { useCombinedAnimation } from '../../hooks/useCombinedAnimation';
@@ -62,8 +62,12 @@ describe('useCombinedAnimation', () => {
         { wrapper: makeWrapper(baseContext) }
       );
       expect(() => {
-        result.current.hideComponent();
-        result.current.showComponent();
+        act(() => {
+          result.current.hideComponent();
+        });
+        act(() => {
+          result.current.showComponent();
+        });
       }).not.toThrow();
     });
   });
@@ -94,8 +98,12 @@ describe('useCombinedAnimation', () => {
         { wrapper: makeWrapper(ctxWithOpacity) }
       );
       expect(() => {
-        result.current.hideComponent();
-        result.current.showComponent();
+        act(() => {
+          result.current.hideComponent();
+        });
+        act(() => {
+          result.current.showComponent();
+        });
       }).not.toThrow();
     });
   });
@@ -158,8 +166,12 @@ describe('useCombinedAnimation', () => {
         { wrapper: makeWrapper(ctxWithSequence) }
       );
       expect(() => {
-        result.current.hideComponent();
-        result.current.showComponent();
+        act(() => {
+          result.current.hideComponent();
+        });
+        act(() => {
+          result.current.showComponent();
+        });
       }).not.toThrow();
     });
   });
@@ -178,8 +190,12 @@ describe('useCombinedAnimation', () => {
         { wrapper: makeWrapper(ctx) }
       );
       expect(() => {
-        result.current.hideComponent();
-        result.current.showComponent();
+        act(() => {
+          result.current.hideComponent();
+        });
+        act(() => {
+          result.current.showComponent();
+        });
       }).not.toThrow();
     });
 
@@ -217,8 +233,12 @@ describe('useCombinedAnimation', () => {
         { wrapper: makeWrapper(ctx) }
       );
       expect(() => {
-        result.current.hideComponent();
-        result.current.showComponent();
+        act(() => {
+          result.current.hideComponent();
+        });
+        act(() => {
+          result.current.showComponent();
+        });
       }).not.toThrow();
     });
 
@@ -242,14 +262,23 @@ describe('useCombinedAnimation', () => {
           animationGap: 50,
         },
       };
+      jest.useFakeTimers();
       expect(() => {
         const { result } = renderHook(
           () => useCombinedAnimation({ index: 999, radians: 0 }),
           { wrapper: makeWrapper(ctx) }
         );
-        result.current.showComponent();
-        result.current.hideComponent();
+        act(() => {
+          result.current.showComponent();
+        });
+        act(() => {
+          result.current.hideComponent();
+        });
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
       }).not.toThrow();
+      jest.useRealTimers();
     });
 
     it('returns static values when no animationProps provided with non-zero radians', () => {

--- a/src/__tests__/hooks/useCombinedAnimation.test.tsx
+++ b/src/__tests__/hooks/useCombinedAnimation.test.tsx
@@ -71,9 +71,9 @@ describe('useCombinedAnimation', () => {
     const ctxWithOpacity: CircleLayoutContextType = {
       ...baseContext,
       animationProps: {
-        animationConfigs: [
-          { type: AnimationType.OPACITY, config: { duration: 300 } },
-        ],
+        animationConfigs: {
+          [AnimationType.OPACITY]: { duration: 300 },
+        },
         animationCombinationType: AnimationCombinationType.PARALLEL,
       },
     };
@@ -103,9 +103,9 @@ describe('useCombinedAnimation', () => {
     const ctxWithLinear: CircleLayoutContextType = {
       ...baseContext,
       animationProps: {
-        animationConfigs: [
-          { type: AnimationType.LINEAR, config: { duration: 300 } },
-        ],
+        animationConfigs: {
+          [AnimationType.LINEAR]: { duration: 300 },
+        },
         animationCombinationType: AnimationCombinationType.PARALLEL,
       },
     };
@@ -123,9 +123,9 @@ describe('useCombinedAnimation', () => {
     const ctxWithCircular: CircleLayoutContextType = {
       ...baseContext,
       animationProps: {
-        animationConfigs: [
-          { type: AnimationType.CIRCULAR, config: { duration: 300 } },
-        ],
+        animationConfigs: {
+          [AnimationType.CIRCULAR]: { duration: 300 },
+        },
         animationCombinationType: AnimationCombinationType.PARALLEL,
       },
     };
@@ -143,9 +143,9 @@ describe('useCombinedAnimation', () => {
     const ctxWithSequence: CircleLayoutContextType = {
       ...baseContext,
       animationProps: {
-        animationConfigs: [
-          { type: AnimationType.OPACITY, config: { duration: 200 } },
-        ],
+        animationConfigs: {
+          [AnimationType.OPACITY]: { duration: 200 },
+        },
         animationCombinationType: AnimationCombinationType.SEQUENCE,
         animationGap: 50,
       },
@@ -164,11 +164,11 @@ describe('useCombinedAnimation', () => {
   });
 
   describe('edge cases', () => {
-    it('handles empty animationConfigs array without throwing', () => {
+    it('handles empty animationConfigs object without throwing', () => {
       const ctx: CircleLayoutContextType = {
         ...baseContext,
         animationProps: {
-          animationConfigs: [],
+          animationConfigs: {},
           animationCombinationType: AnimationCombinationType.PARALLEL,
         },
       };
@@ -186,9 +186,9 @@ describe('useCombinedAnimation', () => {
       const ctx: CircleLayoutContextType = {
         ...baseContext,
         animationProps: {
-          animationConfigs: [
-            { type: AnimationType.CIRCULAR, config: { duration: 300 } },
-          ],
+          animationConfigs: {
+            [AnimationType.CIRCULAR]: { duration: 300 },
+          },
           animationCombinationType: AnimationCombinationType.PARALLEL,
         },
       };
@@ -204,9 +204,9 @@ describe('useCombinedAnimation', () => {
       const ctx: CircleLayoutContextType = {
         ...baseContext,
         animationProps: {
-          animationConfigs: [
-            { type: AnimationType.OPACITY, config: { duration: 300 } },
-          ],
+          animationConfigs: {
+            [AnimationType.OPACITY]: { duration: 300 },
+          },
           animationCombinationType: AnimationCombinationType.SEQUENCE,
           animationGap: 0,
         },
@@ -234,9 +234,9 @@ describe('useCombinedAnimation', () => {
       const ctx: CircleLayoutContextType = {
         ...baseContext,
         animationProps: {
-          animationConfigs: [
-            { type: AnimationType.OPACITY, config: { duration: 100 } },
-          ],
+          animationConfigs: {
+            [AnimationType.OPACITY]: { duration: 100 },
+          },
           animationCombinationType: AnimationCombinationType.SEQUENCE,
           animationGap: 50,
         },

--- a/src/__tests__/hooks/useCombinedAnimation.test.tsx
+++ b/src/__tests__/hooks/useCombinedAnimation.test.tsx
@@ -18,6 +18,7 @@ const baseContext: CircleLayoutContextType = {
   totalParts: 3,
   radius: 100,
   startAngle: 0,
+  sectorAngle: (2 * Math.PI) / 3,
 };
 
 describe('useCombinedAnimation', () => {

--- a/src/__tests__/utils/circle.test.ts
+++ b/src/__tests__/utils/circle.test.ts
@@ -1,6 +1,11 @@
 import { Animated } from 'react-native';
 
-import { pointOnCircle, pointOnCircleAnimated } from '../../utils/circle';
+import {
+  getArcPath,
+  getSectorPath,
+  pointOnCircle,
+  pointOnCircleAnimated,
+} from '../../utils/circle';
 
 const expectListenerValue = (
   animatedValue: Animated.Value | Animated.AnimatedInterpolation<number>,
@@ -10,6 +15,18 @@ const expectListenerValue = (
     expect(value).toBeCloseTo(expectedValue);
   });
 };
+
+/**
+ * Splits an SVG path string into tokens, parsing numeric tokens to numbers.
+ * @param path The SVG path string to parse.
+ * @returns An array of path tokens, where numeric tokens are converted to numbers.
+ * This allows for easier assertions on the structure and values of the path in tests.
+ */
+const parsePathTokens = (path: string): (string | number)[] =>
+  path.split(' ').map((token) => {
+    const num = Number(token);
+    return Number.isNaN(num) ? token : num;
+  });
 
 describe('pointOnCircle', () => {
   it('returns (radius, 0) when radians is 0', () => {
@@ -143,5 +160,140 @@ describe('pointOnCircleAnimated', () => {
         })
       ).not.toThrow();
     });
+  });
+});
+
+describe('getSectorPath', () => {
+  it('builds a clockwise quarter-circle sector path from 0 to π/2', () => {
+    const tokens = parsePathTokens(
+      getSectorPath({ radius: 1, startAngle: 0, endAngle: Math.PI / 2 })
+    );
+
+    expect(tokens[0]).toBe('M');
+    expect(tokens[1]).toBeCloseTo(0); // cx
+    expect(tokens[2]).toBeCloseTo(0); // cy
+    expect(tokens[3]).toBe('L');
+    expect(tokens[4]).toBeCloseTo(-1); // startPoint.x
+    expect(tokens[5]).toBeCloseTo(0); // startPoint.y
+    expect(tokens[6]).toBe('A');
+    expect(tokens[7]).toBe(1); // rx
+    expect(tokens[8]).toBe(1); // ry
+    expect(tokens[9]).toBe(0); // x-axis-rotation
+    expect(tokens[10]).toBe(0); // large-arc-flag (sweep < π)
+    expect(tokens[11]).toBe(1); // sweep-flag (clockwise)
+    expect(tokens[12]).toBeCloseTo(0); // -endPoint.x + cx
+    expect(tokens[13]).toBeCloseTo(-1); // -endPoint.y + cy
+  });
+
+  it('sets sweep-flag to 0 when isClockwise is false', () => {
+    const tokens = parsePathTokens(
+      getSectorPath({
+        radius: 1,
+        startAngle: 0,
+        endAngle: Math.PI / 2,
+        isClockwise: false,
+      })
+    );
+
+    expect(tokens[11]).toBe(0);
+  });
+
+  it('sets large-arc-flag to 1 when the angular sweep is >= π', () => {
+    const tokens = parsePathTokens(
+      getSectorPath({ radius: 1, startAngle: 0, endAngle: Math.PI })
+    );
+
+    expect(tokens[10]).toBe(1);
+  });
+
+  it('sets large-arc-flag to 0 when the angular sweep is < π', () => {
+    const tokens = parsePathTokens(
+      getSectorPath({ radius: 1, startAngle: 0, endAngle: Math.PI / 4 })
+    );
+
+    expect(tokens[10]).toBe(0);
+  });
+
+  it('offsets the path by the given center', () => {
+    const tokens = parsePathTokens(
+      getSectorPath({
+        radius: 2,
+        startAngle: 0,
+        endAngle: Math.PI / 2,
+        center: { x: 5, y: -3 },
+      })
+    );
+
+    expect(tokens[1]).toBeCloseTo(5); // cx
+    expect(tokens[2]).toBeCloseTo(-3); // cy
+    expect(tokens[4]).toBeCloseTo(-2 + 5); // startPoint.x (offset by center)
+    expect(tokens[5]).toBeCloseTo(0 + -3); // startPoint.y (offset by center)
+    expect(tokens[12]).toBeCloseTo(-0 + 5); // -endPoint.x + cx
+    expect(tokens[13]).toBeCloseTo(-2 + -3); // -endPoint.y + cy
+  });
+});
+
+describe('getArcPath', () => {
+  it('builds a clockwise quarter-circle arc path from 0 to π/2', () => {
+    const tokens = parsePathTokens(
+      getArcPath({ radius: 1, startAngle: 0, endAngle: Math.PI / 2 })
+    );
+
+    expect(tokens[0]).toBe('M');
+    expect(tokens[1]).toBeCloseTo(-1); // -startPoint.x + cx
+    expect(tokens[2]).toBeCloseTo(0); // -startPoint.y + cy
+    expect(tokens[3]).toBe('A');
+    expect(tokens[4]).toBe(1); // rx
+    expect(tokens[5]).toBe(1); // ry
+    expect(tokens[6]).toBe(0); // x-axis-rotation
+    expect(tokens[7]).toBe(0); // large-arc-flag (sweep < π)
+    expect(tokens[8]).toBe(1); // sweep-flag (clockwise)
+    expect(tokens[9]).toBeCloseTo(0); // -endPoint.x + cx
+    expect(tokens[10]).toBeCloseTo(-1); // -endPoint.y + cy
+  });
+
+  it('sets sweep-flag to 0 when isClockwise is false', () => {
+    const tokens = parsePathTokens(
+      getArcPath({
+        radius: 1,
+        startAngle: 0,
+        endAngle: Math.PI / 2,
+        isClockwise: false,
+      })
+    );
+
+    expect(tokens[8]).toBe(0);
+  });
+
+  it('sets large-arc-flag to 1 when the angular sweep is >= π', () => {
+    const tokens = parsePathTokens(
+      getArcPath({ radius: 1, startAngle: 0, endAngle: Math.PI })
+    );
+
+    expect(tokens[7]).toBe(1);
+  });
+
+  it('sets large-arc-flag to 0 when the angular sweep is < π', () => {
+    const tokens = parsePathTokens(
+      getArcPath({ radius: 1, startAngle: 0, endAngle: Math.PI / 4 })
+    );
+
+    expect(tokens[7]).toBe(0);
+  });
+
+  it('offsets the path by the given center', () => {
+    const tokens = parsePathTokens(
+      getArcPath({
+        radius: 2,
+        startAngle: 0,
+        endAngle: Math.PI / 2,
+        center: { x: 5, y: -3 },
+      })
+    );
+
+    expect(tokens[1]).toBeCloseTo(-2 + 5); // -startPoint.x + cx
+    expect(tokens[2]).toBeCloseTo(-0 + -3); // -startPoint.y + cy
+    expect(tokens[9]).toBeCloseTo(-0 + 5); // -endPoint.x + cx
+    expect(tokens[10]).toBeCloseTo(-2 + -3); // -endPoint.y + cy
   });
 });

--- a/src/__tests__/utils/circle.test.ts
+++ b/src/__tests__/utils/circle.test.ts
@@ -1,6 +1,6 @@
 import { Animated } from 'react-native';
 
-import { pointOnCircle } from '../../utils/circle';
+import { pointOnCircle, pointOnCircleAnimated } from '../../utils/circle';
 
 const expectListenerValue = (
   animatedValue: Animated.Value | Animated.AnimatedInterpolation<number>,
@@ -31,48 +31,6 @@ describe('pointOnCircle', () => {
 
     expect(result.x).toBeCloseTo(-3);
     expect(result.y).toBeCloseTo(0);
-  });
-
-  it('interpolates x and y when radius is Animated.Value', () => {
-    const result = pointOnCircle({
-      radius: new Animated.Value(2),
-      radians: Math.PI / 4,
-    });
-
-    expectListenerValue(
-      result.x as Animated.AnimatedInterpolation<number>,
-      1.414
-    );
-    expectListenerValue(
-      result.y as Animated.AnimatedInterpolation<number>,
-      1.414
-    );
-  });
-
-  it('interpolates x and y when radians is Animated.Value', () => {
-    const result = pointOnCircle({
-      radius: 4,
-      radians: new Animated.Value(Math.PI / 3),
-    });
-
-    expectListenerValue(result.x as Animated.AnimatedInterpolation<number>, 2);
-    expectListenerValue(
-      result.y as Animated.AnimatedInterpolation<number>,
-      3.464
-    );
-  });
-
-  it('interpolates x and y when both radius and radians are Animated.Value', () => {
-    const result = pointOnCircle({
-      radius: new Animated.Value(2),
-      radians: new Animated.Value(Math.PI / 6),
-    });
-
-    expectListenerValue(result.x as Animated.AnimatedInterpolation<number>, 1);
-    expectListenerValue(
-      result.y as Animated.AnimatedInterpolation<number>,
-      1.732
-    );
   });
 
   describe('edge cases', () => {
@@ -112,16 +70,65 @@ describe('pointOnCircle', () => {
       expect(result.x).toBeCloseTo(-3);
       expect(result.y).toBeCloseTo(0);
     });
+  });
+});
 
+describe('pointOnCircleAnimated', () => {
+  it('interpolates x and y when radius is Animated.Value', () => {
+    const result = pointOnCircleAnimated({
+      radius: new Animated.Value(2),
+      radians: Math.PI / 4,
+    });
+
+    expectListenerValue(
+      result.x as Animated.AnimatedInterpolation<number>,
+      1.414
+    );
+    expectListenerValue(
+      result.y as Animated.AnimatedInterpolation<number>,
+      1.414
+    );
+  });
+
+  it('interpolates x and y when radians is Animated.Value', () => {
+    const result = pointOnCircleAnimated({
+      radius: 4,
+      radians: new Animated.Value(Math.PI / 3),
+    });
+
+    expectListenerValue(result.x as Animated.AnimatedInterpolation<number>, 2);
+    expectListenerValue(
+      result.y as Animated.AnimatedInterpolation<number>,
+      3.464
+    );
+  });
+
+  it('interpolates x and y when both radius and radians are Animated.Value', () => {
+    const result = pointOnCircleAnimated({
+      radius: new Animated.Value(2),
+      radians: new Animated.Value(Math.PI / 6),
+    });
+
+    expectListenerValue(result.x as Animated.AnimatedInterpolation<number>, 1);
+    expectListenerValue(
+      result.y as Animated.AnimatedInterpolation<number>,
+      1.732
+    );
+  });
+
+  describe('edge cases', () => {
     it('does not throw when Animated.Value radians exceeds 2π (extrapolates)', () => {
       expect(() =>
-        pointOnCircle({ radius: 1, radians: new Animated.Value(3 * Math.PI) })
+        pointOnCircleAnimated({
+          radius: 1,
+          radians: new Animated.Value(3 * Math.PI),
+        })
       ).not.toThrow();
     });
 
     it('does not throw when Animated.Value radians is negative (extrapolates)', () => {
       expect(() =>
-        pointOnCircle({
+        pointOnCircleAnimated({
           radius: 1,
           radians: new Animated.Value(-Math.PI / 2),
         })
@@ -130,7 +137,10 @@ describe('pointOnCircle', () => {
 
     it('does not throw when Animated.Value radius is 0', () => {
       expect(() =>
-        pointOnCircle({ radius: new Animated.Value(0), radians: Math.PI / 4 })
+        pointOnCircleAnimated({
+          radius: new Animated.Value(0),
+          radians: Math.PI / 4,
+        })
       ).not.toThrow();
     });
   });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
+export { useAnimatedSectorPath } from './useAnimatedSectorPath';
 export { useAnimation } from './useAnimation';
 export { useCombinedAnimation } from './useCombinedAnimation';

--- a/src/hooks/useAnimatedSectorPath.ts
+++ b/src/hooks/useAnimatedSectorPath.ts
@@ -1,0 +1,119 @@
+import { Animated } from 'react-native';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { getSectorPath, interpolationWithFunction } from '../utils';
+
+type UseAnimatedSectorPath = {
+  /**
+   * The radius of the sector. Can be a static number or an animated value.
+   */
+  radius: Animated.Value | number;
+  /**
+   * The angle at which the sector starts, in radians.
+   */
+  startAngle: number;
+  /**
+   * The angle at which the sector ends. Can be a static number or an animated value.
+   */
+  endAngle: Animated.Value | number;
+  /**
+   * The center point of the circle on which the sector is drawn.
+   */
+  center: { x: number; y: number };
+};
+
+/**
+ * Derives the SVG path for an animated sector from a (possibly animated)
+ * radius and end angle.
+ *
+ * `Animated.Value` only accepts numeric values, so a path string can't be
+ * driven by a single animated node. When only one of `radius`/`endAngle` is
+ * animated (or neither is), the path is a pure derivation of the current
+ * props and is computed via `interpolationWithFunction`/`getSectorPath` in
+ * `useMemo`, staying on the native-driven interpolation path where possible.
+ * When BOTH are animated, the two values tick independently, so the path is
+ * recomputed from listeners that track the latest known numbers in refs
+ * (avoiding stale closures) and is surfaced via React state, updated only
+ * from those listener callbacks (an external system subscription), never
+ * synchronously within the effect body.
+ * @param props The properties for deriving the animated sector path.
+ * @param props.radius The radius of the sector. Can be a static number or an animated value.
+ * @param props.startAngle The angle at which the sector starts, in radians.
+ * @param props.endAngle The angle at which the sector ends. Can be a static number or an animated value.
+ * @param props.center The center point of the circle on which the sector is drawn.
+ * @returns The animated (or static) SVG path for the sector.
+ */
+export const useAnimatedSectorPath = ({
+  radius,
+  startAngle,
+  endAngle,
+  center,
+}: UseAnimatedSectorPath) => {
+  const bothAnimated =
+    radius instanceof Animated.Value && endAngle instanceof Animated.Value;
+
+  const derivedPath = useMemo<
+    Animated.AnimatedInterpolation<string> | string | undefined
+  >(() => {
+    if (bothAnimated) return undefined;
+
+    if (radius instanceof Animated.Value) {
+      return interpolationWithFunction(radius, (s) =>
+        getSectorPath({
+          radius: s,
+          startAngle,
+          endAngle: endAngle as number,
+          center,
+        })
+      );
+    }
+
+    if (endAngle instanceof Animated.Value) {
+      return interpolationWithFunction(
+        endAngle,
+        (r) => getSectorPath({ radius, startAngle, endAngle: r, center }),
+        { endValue: Math.PI * 2 }
+      );
+    }
+
+    return getSectorPath({ radius, startAngle, endAngle, center });
+  }, [bothAnimated, radius, endAngle, startAngle, center]);
+
+  const [listenerPath, setListenerPath] = useState('');
+  const currentRadiusRef = useRef(0);
+  const currentEndAngleRef = useRef(0);
+
+  useEffect(() => {
+    if (!bothAnimated) return;
+
+    const animatedRadius = radius as Animated.Value;
+    const animatedEndAngle = endAngle as Animated.Value;
+
+    const recalculatePath = () => {
+      setListenerPath(
+        getSectorPath({
+          radius: currentRadiusRef.current,
+          startAngle,
+          endAngle: currentEndAngleRef.current,
+          center,
+        })
+      );
+    };
+
+    const radiusListenerId = animatedRadius.addListener(({ value }) => {
+      currentRadiusRef.current = value;
+      recalculatePath();
+    });
+    const endAngleListenerId = animatedEndAngle.addListener(({ value }) => {
+      currentEndAngleRef.current = value;
+      recalculatePath();
+    });
+
+    return () => {
+      animatedRadius.removeListener(radiusListenerId);
+      animatedEndAngle.removeListener(endAngleListenerId);
+    };
+  }, [bothAnimated, radius, endAngle, startAngle, center]);
+
+  return bothAnimated ? listenerPath : (derivedPath ?? '');
+};

--- a/src/hooks/useAnimation.ts
+++ b/src/hooks/useAnimation.ts
@@ -1,10 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Animated } from 'react-native';
 
-type AnimationProps = Omit<
-  Animated.TimingAnimationConfig,
-  'toValue' | 'useNativeDriver'
->;
+import type { AnimationConfig } from '../types';
 
 interface AnimationArgs {
   /**
@@ -18,11 +15,11 @@ interface AnimationArgs {
   /**
    * The configuration for the entry animation.
    */
-  entryAnimationConfig: AnimationProps;
+  entryAnimationConfig: AnimationConfig;
   /**
    * The configuration for the exit animation.
    */
-  exitAnimationConfig?: AnimationProps;
+  exitAnimationConfig?: AnimationConfig;
 }
 
 const EPSILON = 0.0001;

--- a/src/hooks/useAnimation.ts
+++ b/src/hooks/useAnimation.ts
@@ -89,7 +89,7 @@ export const useAnimation = ({
   const entryAnimation = useCallback(
     () =>
       Animated.timing(value, {
-        useNativeDriver: true,
+        useNativeDriver: false,
         toValue: finalValue,
         ...entryAnimationConfig,
       }),
@@ -102,7 +102,7 @@ export const useAnimation = ({
   const exitAnimation = useCallback(
     () =>
       Animated.timing(value, {
-        useNativeDriver: true,
+        useNativeDriver: false,
         toValue: initialValue,
         ...exitAnimationConfig,
       }),

--- a/src/hooks/useAnimation.ts
+++ b/src/hooks/useAnimation.ts
@@ -20,6 +20,11 @@ interface AnimationArgs {
    * The configuration for the exit animation.
    */
   exitAnimationConfig?: AnimationConfig;
+  /**
+   * Whether to use the native animation driver.
+   * @default true
+   */
+  useNativeDriver?: boolean;
 }
 
 const EPSILON = 0.0001;
@@ -32,6 +37,7 @@ const EPSILON = 0.0001;
  * @param props.finalValue The end value of the animated value.
  * @param props.entryAnimationConfig The configuration for the entry animation.
  * @param props.exitAnimationConfig The configuration for the exit animation.
+ * @param props.useNativeDriver Whether to use the native animation driver. Defaults to true.
  * @returns The an object containing the animated value on which
  * the animation will be performed, the entry and exit animation function.
  */
@@ -40,6 +46,7 @@ export const useAnimation = ({
   finalValue,
   entryAnimationConfig,
   exitAnimationConfig = entryAnimationConfig,
+  useNativeDriver = true,
 }: AnimationArgs) => {
   const [value] = useState(() => new Animated.Value(initialValue));
 
@@ -89,11 +96,11 @@ export const useAnimation = ({
   const entryAnimation = useCallback(
     () =>
       Animated.timing(value, {
-        useNativeDriver: false,
         toValue: finalValue,
         ...entryAnimationConfig,
+        useNativeDriver,
       }),
-    [entryAnimationConfig, finalValue, value]
+    [entryAnimationConfig, finalValue, useNativeDriver, value]
   );
 
   /**
@@ -102,11 +109,11 @@ export const useAnimation = ({
   const exitAnimation = useCallback(
     () =>
       Animated.timing(value, {
-        useNativeDriver: false,
         toValue: initialValue,
         ...exitAnimationConfig,
+        useNativeDriver,
       }),
-    [exitAnimationConfig, initialValue, value]
+    [exitAnimationConfig, initialValue, useNativeDriver, value]
   );
 
   return { value, entryAnimation, exitAnimation };

--- a/src/hooks/useCombinedAnimation.ts
+++ b/src/hooks/useCombinedAnimation.ts
@@ -15,6 +15,18 @@ type UseCombinedAnimation = {
    * The angle at which this component will be placed on the circle.
    */
   radians: number;
+  /**
+   * The angle from which the component will start its circular animation.
+   * Defaults to the starting angle of the context if not provided.
+   */
+  startAngle?: number;
+  /**
+   * The radius from which the component will end its linear animation.
+   * The component will start its linear animation from the center of the
+   * circle (radius 0) to this radius value.
+   * Defaults to context radius value if not provided.
+   */
+  radius?: number;
 };
 
 /**
@@ -23,15 +35,25 @@ type UseCombinedAnimation = {
  * @param props The props passed to the hook.
  * @param props.index The value of the component that is plotted.
  * @param props.radians The angle at which this component will be placed on the circle.
+ * @param props.startAngle The angle from which the component will start its circular animation.
+ * Defaults to the starting angle of the context if not provided.
+ * @param props.radius The radius from which the component will start its linear animation.
+ * Defaults to context radius value if not provided.
  * @returns An object containing animated value for the animation config passed,
  * the entry and exit functions and the visibility state of the component.
  */
 export const useCombinedAnimation = ({
   index,
   radians,
+  startAngle,
+  radius,
 }: UseCombinedAnimation) => {
-  const { totalParts, animationProps, radius, startAngle } =
-    React.use(CircleLayoutContext);
+  const {
+    totalParts,
+    animationProps,
+    radius: contextRadius,
+    startAngle: contextStartAngle,
+  } = React.use(CircleLayoutContext);
 
   const opacityAnimationConfig =
     animationProps?.animationConfigs[AnimationType.OPACITY];
@@ -75,13 +97,13 @@ export const useCombinedAnimation = ({
     exitAnimation: linearExitAnimation,
   } = useAnimation({
     initialValue: 0,
-    finalValue: radius,
+    finalValue: radius ?? contextRadius,
     entryAnimationConfig: linearAnimationConfig ?? {},
   });
   // The value of radius depending on the props of the component.
   const radiusValue = useMemo(
-    () => (linearAnimationConfig && animatedRadius) || radius,
-    [linearAnimationConfig, radius, animatedRadius]
+    () => (linearAnimationConfig && animatedRadius) || radius || contextRadius,
+    [linearAnimationConfig, radius, animatedRadius, contextRadius]
   );
 
   /**
@@ -94,7 +116,7 @@ export const useCombinedAnimation = ({
     entryAnimation: circularEntryAnimation,
     exitAnimation: circularExitAnimation,
   } = useAnimation({
-    initialValue: startAngle,
+    initialValue: startAngle ?? contextStartAngle,
     finalValue: radians,
     entryAnimationConfig: circularAnimationConfig ?? {},
   });
@@ -176,6 +198,8 @@ export const useCombinedAnimation = ({
           });
           break;
       }
+    } else {
+      setComponentVisible(false);
     }
   }, [animationProps?.animationCombinationType, exitAnimationList]);
 
@@ -196,8 +220,14 @@ export const useCombinedAnimation = ({
           });
           break;
       }
+    } else {
+      setComponentVisible(true);
     }
-  }, [animationProps?.animationCombinationType, entryAnimationList]);
+  }, [
+    animationProps?.animationCombinationType,
+    entryAnimationList,
+    setComponentVisible,
+  ]);
 
   return {
     opacityValue,

--- a/src/hooks/useCombinedAnimation.ts
+++ b/src/hooks/useCombinedAnimation.ts
@@ -27,6 +27,11 @@ type UseCombinedAnimation = {
    * Defaults to context radius value if not provided.
    */
   radius?: number;
+  /**
+   * Whether to use the native animation driver for timing animations.
+   * @default true
+   */
+  useNativeDriver?: boolean;
 };
 
 /**
@@ -39,6 +44,8 @@ type UseCombinedAnimation = {
  * Defaults to the starting angle of the context if not provided.
  * @param props.radius The radius from which the component will start its linear animation.
  * Defaults to context radius value if not provided.
+ * @param props.useNativeDriver Whether to use the native animation driver for timing animations.
+ * Defaults to true.
  * @returns An object containing animated value for the animation config passed,
  * the entry and exit functions and the visibility state of the component.
  */
@@ -47,6 +54,7 @@ export const useCombinedAnimation = ({
   radians,
   startAngle,
   radius,
+  useNativeDriver = true,
 }: UseCombinedAnimation) => {
   const {
     totalParts,
@@ -78,6 +86,7 @@ export const useCombinedAnimation = ({
     initialValue: 0,
     finalValue: 1,
     entryAnimationConfig: opacityAnimationConfig ?? {},
+    useNativeDriver,
   });
   // The value of opacity depending on the props of the component.
   const opacityValue = React.useMemo(
@@ -99,6 +108,7 @@ export const useCombinedAnimation = ({
     initialValue: 0,
     finalValue: radius ?? contextRadius,
     entryAnimationConfig: linearAnimationConfig ?? {},
+    useNativeDriver,
   });
   // The value of radius depending on the props of the component.
   const radiusValue = useMemo(
@@ -119,6 +129,7 @@ export const useCombinedAnimation = ({
     initialValue: startAngle ?? contextStartAngle,
     finalValue: radians,
     entryAnimationConfig: circularAnimationConfig ?? {},
+    useNativeDriver,
   });
   // The value of radians depending on the props of the component.
   const radiansValue = useMemo(

--- a/src/hooks/useCombinedAnimation.ts
+++ b/src/hooks/useCombinedAnimation.ts
@@ -133,31 +133,33 @@ export const useCombinedAnimation = ({
 
       const { entryList, exitList } = (
         Object.keys(animationProps.animationConfigs) as AnimationType[]
-      ).reduce(
-        ({ entryList: entry, exitList: exit }, type) => {
-          switch (type) {
-            case AnimationType.OPACITY:
-              entry.push(opacityEntryAnimation());
-              exit.unshift(opacityExitAnimation());
-              break;
-            case AnimationType.LINEAR:
-              entry.push(linearEntryAnimation());
-              exit.unshift(linearExitAnimation());
-              break;
-            case AnimationType.CIRCULAR:
-              entry.push(circularEntryAnimation());
-              exit.unshift(circularExitAnimation());
-              break;
-            default:
-              throw new Error('Unrecognized config type');
+      )
+        .filter((type) => animationProps.animationConfigs[type] !== undefined)
+        .reduce(
+          ({ entryList: entry, exitList: exit }, type) => {
+            switch (type) {
+              case AnimationType.OPACITY:
+                entry.push(opacityEntryAnimation());
+                exit.unshift(opacityExitAnimation());
+                break;
+              case AnimationType.LINEAR:
+                entry.push(linearEntryAnimation());
+                exit.unshift(linearExitAnimation());
+                break;
+              case AnimationType.CIRCULAR:
+                entry.push(circularEntryAnimation());
+                exit.unshift(circularExitAnimation());
+                break;
+              default:
+                throw new Error('Unrecognized config type');
+            }
+            return { entryList: entry, exitList: exit };
+          },
+          {
+            entryList: [] as Animated.CompositeAnimation[],
+            exitList: [] as Animated.CompositeAnimation[],
           }
-          return { entryList: entry, exitList: exit };
-        },
-        {
-          entryList: [] as Animated.CompositeAnimation[],
-          exitList: [] as Animated.CompositeAnimation[],
-        }
-      );
+        );
 
       entryList.unshift(
         Animated.delay(index * (animationProps.animationGap ?? 0))

--- a/src/hooks/useCombinedAnimation.ts
+++ b/src/hooks/useCombinedAnimation.ts
@@ -33,15 +33,12 @@ export const useCombinedAnimation = ({
   const { totalParts, animationProps, radius, startAngle } =
     React.use(CircleLayoutContext);
 
-  const opacityAnimationConfig = animationProps?.animationConfigs.find(
-    (config) => config.type === AnimationType.OPACITY
-  );
-  const linearAnimationConfig = animationProps?.animationConfigs.find(
-    (config) => config.type === AnimationType.LINEAR
-  );
-  const circularAnimationConfig = animationProps?.animationConfigs.find(
-    (config) => config.type === AnimationType.CIRCULAR
-  );
+  const opacityAnimationConfig =
+    animationProps?.animationConfigs[AnimationType.OPACITY];
+  const linearAnimationConfig =
+    animationProps?.animationConfigs[AnimationType.LINEAR];
+  const circularAnimationConfig =
+    animationProps?.animationConfigs[AnimationType.CIRCULAR];
 
   /**
    * A flag to determine the visibility state of the component.
@@ -58,7 +55,7 @@ export const useCombinedAnimation = ({
   } = useAnimation({
     initialValue: 0,
     finalValue: 1,
-    entryAnimationConfig: opacityAnimationConfig?.config ?? {},
+    entryAnimationConfig: opacityAnimationConfig ?? {},
   });
   // The value of opacity depending on the props of the component.
   const opacityValue = React.useMemo(
@@ -79,7 +76,7 @@ export const useCombinedAnimation = ({
   } = useAnimation({
     initialValue: 0,
     finalValue: radius,
-    entryAnimationConfig: linearAnimationConfig?.config ?? {},
+    entryAnimationConfig: linearAnimationConfig ?? {},
   });
   // The value of radius depending on the props of the component.
   const radiusValue = useMemo(
@@ -99,7 +96,7 @@ export const useCombinedAnimation = ({
   } = useAnimation({
     initialValue: startAngle,
     finalValue: radians,
-    entryAnimationConfig: circularAnimationConfig?.config ?? {},
+    entryAnimationConfig: circularAnimationConfig ?? {},
   });
   // The value of radians depending on the props of the component.
   const radiansValue = useMemo(
@@ -107,64 +104,60 @@ export const useCombinedAnimation = ({
     [circularAnimationConfig, radians, animatedRadians]
   );
 
-  const entryAnimationList = React.useMemo(() => {
-    if (animationProps === undefined) return undefined;
+  const { entryList: entryAnimationList, exitList: exitAnimationList } =
+    React.useMemo(() => {
+      if (animationProps === undefined)
+        return { entryList: undefined, exitList: undefined };
 
-    const list = animationProps.animationConfigs.map((animationConfig) => {
-      switch (animationConfig.type) {
-        case AnimationType.OPACITY:
-          return opacityEntryAnimation();
-        case AnimationType.LINEAR:
-          return linearEntryAnimation();
-        case AnimationType.CIRCULAR:
-          return circularEntryAnimation();
-        default:
-          throw new Error('Unrecognized config type');
-      }
-    });
-
-    list?.unshift(Animated.delay(index * (animationProps.animationGap ?? 0)));
-    return list;
-  }, [
-    animationProps,
-    circularEntryAnimation,
-    index,
-    linearEntryAnimation,
-    opacityEntryAnimation,
-  ]);
-
-  const exitAnimationList = React.useMemo(() => {
-    if (animationProps === undefined) return undefined;
-
-    const list = animationProps?.animationConfigs
-      ?.map((animationConfig) => {
-        switch (animationConfig.type) {
-          case AnimationType.OPACITY:
-            return opacityExitAnimation();
-          case AnimationType.LINEAR:
-            return linearExitAnimation();
-          case AnimationType.CIRCULAR:
-            return circularExitAnimation();
-          default:
-            throw new Error('Unrecognized config type');
+      const { entryList, exitList } = (
+        Object.keys(animationProps.animationConfigs) as AnimationType[]
+      ).reduce(
+        ({ entryList: entry, exitList: exit }, type) => {
+          switch (type) {
+            case AnimationType.OPACITY:
+              entry.push(opacityEntryAnimation());
+              exit.unshift(opacityExitAnimation());
+              break;
+            case AnimationType.LINEAR:
+              entry.push(linearEntryAnimation());
+              exit.unshift(linearExitAnimation());
+              break;
+            case AnimationType.CIRCULAR:
+              entry.push(circularEntryAnimation());
+              exit.unshift(circularExitAnimation());
+              break;
+            default:
+              throw new Error('Unrecognized config type');
+          }
+          return { entryList: entry, exitList: exit };
+        },
+        {
+          entryList: [] as Animated.CompositeAnimation[],
+          exitList: [] as Animated.CompositeAnimation[],
         }
-      })
-      .reverse();
+      );
 
-    list.unshift(
-      Animated.delay(
-        (totalParts - index - 1) * (animationProps.animationGap ?? 0)
-      )
-    );
-    return list;
-  }, [
-    animationProps,
-    circularExitAnimation,
-    index,
-    linearExitAnimation,
-    opacityExitAnimation,
-    totalParts,
-  ]);
+      entryList.unshift(
+        Animated.delay(index * (animationProps.animationGap ?? 0))
+      );
+      exitList.unshift(
+        Animated.delay(
+          (totalParts - index - 1) * (animationProps.animationGap ?? 0)
+        )
+      );
+
+      return { entryList, exitList };
+    }, [
+      animationProps,
+      circularEntryAnimation,
+      circularExitAnimation,
+      index,
+      linearEntryAnimation,
+      linearExitAnimation,
+      opacityEntryAnimation,
+      opacityExitAnimation,
+      totalParts,
+    ]);
 
   /**
    * Function to hide the component by performing the animation configs passed.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,7 @@
 export { CircleLayout } from './CircleLayout';
 export { AnimationCombinationType, AnimationType } from './types';
-export type { CircleLayoutProps, CircleLayoutRef } from './types';
+export type {
+  AnimationConfig,
+  CircleLayoutProps,
+  CircleLayoutRef,
+} from './types';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ export { CircleLayout } from './CircleLayout';
 export { AnimationCombinationType, AnimationType } from './types';
 export type {
   AnimationConfig,
+  BgConfig,
   CircleLayoutProps,
   CircleLayoutRef,
 } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,6 +209,11 @@ export type CircleLayoutContextType = {
    * @default undefined
    */
   animationProps?: AnimationProps | undefined;
+  /**
+   * The angle in radians between the position of 2 consecutive components on the circle.
+   * This value is calculated by dividing the sweepAngle by the total number of parts.
+   */
+  sectorAngle: number;
 };
 
 export type Layout = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,7 +97,7 @@ export type BgConfig = {
   color?: string;
   /**
    * The stroke color for the divider lines in the background.
-   * @default #3d19e027
+   * @default color
    */
   strokeColor?: string;
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,44 @@ type AnimationProps = {
   animationGap?: number;
 };
 
+export type BgConfig = {
+  /**
+   * The fill color for the background of the circle layout.
+   * @default #3d19e0
+   */
+  color?: string;
+  /**
+   * The stroke color for the divider lines in the background.
+   * @default #3d19e027
+   */
+  strokeColor?: string;
+  /**
+   * The width of the stroke for the divider lines in the background.
+   * @default 1
+   */
+  strokeWidth?: number;
+  /**
+   * The radius of the inner circle in the background.
+   * If this prop is not provided, then there will be no inner circle in
+   * the background and the background will be a filled circle with the
+   * radius provided in the CircleLayoutProps.
+   * If this prop is provided, then the background will have a donut shape
+   * with the outer radius provided in the CircleLayoutProps and the
+   * inner radius provided in this prop.
+   * @default 0
+   */
+  innerRadius?: number;
+  /**
+   * The radius of the outer circle in the background.
+   * If this prop is not provided, then the radius provided in the
+   * CircleLayoutProps will be used as the outer radius of the background.
+   * @default radius provided in CircleLayoutProps
+   * @see CircleLayoutProps.radius
+   * @see BgConfig.innerRadius
+   */
+  outerRadius?: number;
+};
+
 export type CircleLayoutProps = {
   /**
    * The list of components that needs to be placed in the circle.
@@ -132,6 +170,12 @@ export type CircleLayoutProps = {
    * @see AnimationProps
    */
   animationProps?: AnimationProps;
+  /**
+   * The fill color for the background of the circle layout.
+   * If this prop is not provided, then the background will not be shown.
+   * @default undefined
+   */
+  bgConfig?: BgConfig | undefined;
 };
 
 export type CircleLayoutRef = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,49 +41,43 @@ export enum AnimationCombinationType {
   SEQUENCE = 'sequence',
 }
 
-export type AnimationConfig = {
-  /**
-   * The type of animation to be used for the entry and exit
-   * animations of the components.
-   * @see AnimationType
-   */
-  type: AnimationType;
-  /**
-   * The configuration for the animation.
-   * @default undefined
-   * @see https://reactnative.dev/docs/animated#timing
-   */
-  config?: Omit<Animated.TimingAnimationConfig, 'toValue' | 'useNativeDriver'>;
-};
+/**
+ * The configuration for the animation.
+ * @default undefined
+ * @see https://reactnative.dev/docs/animated#timing
+ */
+export type AnimationConfig = Omit<
+  Animated.TimingAnimationConfig,
+  'toValue' | 'useNativeDriver'
+>;
 
 type AnimationProps = {
   /**
-   * Array of animations to be performed on entry and exit of components.
+   * The configuration for the animation. The key of the record is the type of
+   * animation and the value is the configuration for that animation. If a particular
+   * animation type is not provided, then that animation will not be performed.
+   *
+   * The order of the animation is determined by the key order of the object.
+   * @see AnimationType
    * @see AnimationConfig
    * @example
-   * [
-   *  {
-   *   type: AnimationType.OPACITY,
-   *   config: {
+   * {
+   *  [AnimationType.OPACITY]: {
    *    duration: 500,
    *    easing: Easing.inOut(Easing.ease),
-   *   },
    *  },
-   *  {
-   *   type: AnimationType.LINEAR,
-   *   config: {
+   *  [AnimationType.LINEAR]: {
    *    duration: 500,
-   *   },
    *  },
-   * ]
+   * }
    */
-  animationConfigs: AnimationConfig[];
+  animationConfigs: Partial<Record<AnimationType, AnimationConfig>>;
   /**
    * The type of composition animation to be performed with
    * all the animation configs provided.
    *
    * For those composition which perform animation in a particular order,
-   * the order is picked by the order in the animationConfig array.
+   * the order is picked by the key order of the animationConfigs object.
    * @see AnimationCombinationType
    */
   animationCombinationType: AnimationCombinationType;

--- a/src/utils/animation.ts
+++ b/src/utils/animation.ts
@@ -1,4 +1,4 @@
-import type { Animated } from 'react-native';
+import { Animated } from 'react-native';
 
 type InterpolationConfig = {
   /**
@@ -37,25 +37,21 @@ type InterpolationConfig = {
  * console.log(result.inputRange); // [0, 2, 4, 6, 8, 10]
  * console.log(result.outputRange); // [0, 4, 8, 12, 16, 20]
  */
-export const withFunction = (
-  callback: (value: number) => number,
+export const withFunction = <T extends number | string>(
+  callback: (value: number) => T,
   interpolationConfig?: InterpolationConfig
 ) => {
   const {
     startValue = 0,
     endValue = 1,
     totalIterations = 50,
-  } = interpolationConfig ?? {
-    startValue: 0,
-    endValue: 1,
-    totalIterations: 50,
-  };
+  } = interpolationConfig ?? {};
 
   if (totalIterations < 0)
     throw new Error('totalIterations cannot be negative');
 
   const inputRange: number[] = [];
-  const outputRange: number[] = [];
+  const outputRange: T[] = [];
 
   if (totalIterations === 0) return { inputRange, outputRange };
 
@@ -79,16 +75,16 @@ export const withFunction = (
  * @param animatedInterpolationConfig The configuration for the animated interpolation.
  * @returns Animated Interpolation value
  */
-export const interpolationWithFunction = (
-  value: Animated.Value,
-  callback: (value: number) => number,
+export const interpolationWithFunction = <T extends number | string>(
+  value: Animated.Value | Animated.AnimatedInterpolation<number>,
+  callback: (value: number) => T,
   interpolationConfig?: InterpolationConfig,
   animatedInterpolationConfig?: Omit<
     Animated.InterpolationConfig<number>,
     'inputRange' | 'outputRange'
   >
-) =>
-  value.interpolate<number>({
+): Animated.AnimatedInterpolation<T> =>
+  (value as Animated.Value).interpolate<T>({
     ...withFunction(callback, interpolationConfig),
     ...animatedInterpolationConfig,
   });

--- a/src/utils/circle.ts
+++ b/src/utils/circle.ts
@@ -178,6 +178,7 @@ export function getSectorPath({
     -startPoint.y + cy,
     'A',
     ...arc,
+    'Z',
   ].join(' ');
 }
 

--- a/src/utils/circle.ts
+++ b/src/utils/circle.ts
@@ -2,6 +2,16 @@ import { Animated } from 'react-native';
 
 import { interpolationWithFunction } from './animation';
 
+type Point = {
+  x: number;
+  y: number;
+};
+
+type PointAnimated = {
+  x: Animated.AnimatedInterpolation<number>;
+  y: Animated.AnimatedInterpolation<number>;
+};
+
 /**
  * The props of the polar co-ordinate of a point on the circle.
  */
@@ -23,7 +33,7 @@ export type PointOnCircle = {
  * @param props.radians The angle of the point on the circle.
  * @returns The x co-ordinate of the point on the circle.
  */
-function pointOnCircleX({ radius, radians }: PointOnCircle) {
+function pointOnCircleX({ radius, radians }: PointOnCircle): number {
   return radius * Math.cos(radians);
 }
 
@@ -34,7 +44,7 @@ function pointOnCircleX({ radius, radians }: PointOnCircle) {
  * @param props.radians The angle of the point on the circle.
  * @returns The y co-ordinate of the point on the circle.
  */
-function pointOnCircleY({ radius, radians }: PointOnCircle) {
+function pointOnCircleY({ radius, radians }: PointOnCircle): number {
   return radius * Math.sin(radians);
 }
 
@@ -46,7 +56,7 @@ function pointOnCircleY({ radius, radians }: PointOnCircle) {
  * @param props.radians The angle of the point on the circle.
  * @returns The Cartesian co-ordinates of the point of the circle.
  */
-export function pointOnCircle({ radius, radians }: PointOnCircle) {
+export function pointOnCircle({ radius, radians }: PointOnCircle): Point {
   return {
     x: pointOnCircleX({ radius, radians }),
     y: pointOnCircleY({ radius, radians }),
@@ -80,7 +90,7 @@ export type PointOnCircleAnimated = {
 export function pointOnCircleAnimated({
   radians,
   radius,
-}: PointOnCircleAnimated) {
+}: PointOnCircleAnimated): PointAnimated {
   if (typeof radians === 'number') {
     if (typeof radius === 'number') {
       throw new Error(
@@ -117,4 +127,138 @@ export function pointOnCircleAnimated({
       ),
     };
   }
+}
+
+/**
+ * The properties for creating an SVG path of a circle.
+ */
+type CirclePathProps = {
+  radius: number;
+  startAngle: number;
+  endAngle: number;
+  isClockwise?: boolean;
+  center?: Point;
+};
+
+/**
+ * Creates an SVG path for a sector of a circle based on the provided properties.
+ * The path is created using the format:
+ * M cx cy L startPoint.x startPoint.y A radius radius 0 largeArcFlag sweepFlag endPoint.x endPoint.y Z
+ * @param props The properties of the sector.
+ * @param props.radius The radius of the sector.
+ * @param props.startAngle The angle at which the sector starts. The value needs to be in radians.
+ * @param props.endAngle The angle at which the sector ends. The value needs to be in radians.
+ * @param props.isClockwise Whether the sector is drawn in a clockwise direction or not. The default value is true.
+ * @param props.center The center point of the circle on which the sector is drawn. The default value is { x: 0, y: 0 }.
+ * @param props.center.x The x-coordinate of the center point.
+ * @param props.center.y The y-coordinate of the center point.
+ * @returns The SVG path for the sector.
+ */
+export function getSectorPath({
+  radius,
+  startAngle,
+  endAngle,
+  isClockwise = true,
+  center: { x: cx, y: cy } = { x: 0, y: 0 },
+}: CirclePathProps): string {
+  const { startPoint, arc } = getArc({
+    radius,
+    startAngle,
+    endAngle,
+    isClockwise,
+    center: { x: cx, y: cy },
+  });
+
+  return [
+    'M',
+    cx,
+    cy,
+    'L',
+    -startPoint.x + cx,
+    -startPoint.y + cy,
+    'A',
+    ...arc,
+  ].join(' ');
+}
+
+/**
+ * Creates an SVG path for an arc of a circle based on the provided properties.
+ * The path is created using the format:
+ * M startPoint.x startPoint.y A radius radius 0 largeArcFlag sweepFlag endPoint.x endPoint.y
+ * @param params The properties for creating the SVG path of an arc.
+ * @param params.radius The radius of the arc.
+ * @param params.startAngle The angle at which the arc starts, in radians.
+ * @param params.endAngle The angle at which the arc ends, in radians.
+ * @param params.isClockwise Whether the arc is drawn in a clockwise direction
+ * or not. The default value is true.
+ * @param params.center The center point of the circle on which the arc is drawn.
+ * The default value is { x: 0, y: 0 }.
+ * @param params.center.x The x-coordinate of the center point.
+ * @param params.center.y The y-coordinate of the center point.
+ * @returns The SVG path for the arc.
+ */
+export function getArcPath({
+  radius,
+  startAngle,
+  endAngle,
+  isClockwise = true,
+  center: { x: cx, y: cy } = { x: 0, y: 0 },
+}: CirclePathProps): string {
+  const { startPoint, arc } = getArc({
+    radius,
+    startAngle,
+    endAngle,
+    isClockwise,
+    center: { x: cx, y: cy },
+  });
+
+  return ['M', -startPoint.x + cx, -startPoint.y + cy, 'A', ...arc].join(' ');
+}
+
+/**
+ * Creates the parameters for an SVG arc based on the provided properties.
+ * The parameters are created in the format:
+ * [
+ *     radius for x-axis,
+ *     radius for y-axis,
+ *     rotation,
+ *     largeArcFlag,
+ *     sweepFlag,
+ *     x coordinate of the end point,
+ *     y coordinate of the end point
+ * ]
+ * @param params The properties for creating an SVG arc.
+ * @param params.radius The radius of the arc.
+ * @param params.startAngle The angle at which the arc starts, in radians.
+ * @param params.endAngle The angle at which the arc ends, in radians.
+ * @param params.isClockwise Whether the arc is drawn in a clockwise direction
+ * or not. The default value is true.
+ * @param params.center The center point of the circle on which the arc is drawn.
+ * The default value is { x: 0, y: 0 }.
+ * @param params.center.x The x-coordinate of the center point.
+ * @param params.center.y The y-coordinate of the center point.
+ * @returns An object containing the start point and the arc parameters for the SVG path.
+ */
+function getArc({
+  radius,
+  startAngle,
+  endAngle,
+  isClockwise = true,
+  center: { x: cx, y: cy } = { x: 0, y: 0 },
+}: CirclePathProps): { startPoint: Point; arc: number[] } {
+  const startPoint = pointOnCircle({ radius, radians: startAngle });
+  const endPoint = pointOnCircle({ radius, radians: endAngle });
+
+  return {
+    startPoint,
+    arc: [
+      radius,
+      radius,
+      0,
+      endAngle - startAngle >= Math.PI ? 1 : 0,
+      isClockwise ? 1 : 0,
+      -endPoint.x + cx,
+      -endPoint.y + cy,
+    ],
+  };
 }

--- a/src/utils/circle.ts
+++ b/src/utils/circle.ts
@@ -9,12 +9,34 @@ export type PointOnCircle = {
   /**
    * The radius of the circle.
    */
-  radius: number | Animated.Value;
+  radius: number;
   /**
    * The angle of the point on the circle.
    */
-  radians: number | Animated.Value;
+  radians: number;
 };
+
+/**
+ * Computes the x co-ordinate of a point on a circle. x = r cos θ
+ * @param props The property of the circle
+ * @param props.radius The radius of the circle.
+ * @param props.radians The angle of the point on the circle.
+ * @returns The x co-ordinate of the point on the circle.
+ */
+function pointOnCircleX({ radius, radians }: PointOnCircle) {
+  return radius * Math.cos(radians);
+}
+
+/**
+ * Computes the y co-ordinate of a point on a circle. y = r sin θ
+ * @param props The property of the circle
+ * @param props.radius The radius of the circle.
+ * @param props.radians The angle of the point on the circle.
+ * @returns The y co-ordinate of the point on the circle.
+ */
+function pointOnCircleY({ radius, radians }: PointOnCircle) {
+  return radius * Math.sin(radians);
+}
 
 /**
  * Converts the polar co-ordinates of a point on a circle to its Cartesian co-ordinate.
@@ -24,44 +46,75 @@ export type PointOnCircle = {
  * @param props.radians The angle of the point on the circle.
  * @returns The Cartesian co-ordinates of the point of the circle.
  */
-export const pointOnCircle = ({ radius, radians }: PointOnCircle) => {
-  if (typeof radius !== 'number') {
-    if (typeof radians === 'number') {
+export function pointOnCircle({ radius, radians }: PointOnCircle) {
+  return {
+    x: pointOnCircleX({ radius, radians }),
+    y: pointOnCircleY({ radius, radians }),
+  };
+}
+
+/**
+ * The props of the polar co-ordinate of a point on the circle.
+ */
+export type PointOnCircleAnimated = {
+  /**
+   * The radius of the circle.
+   */
+  radius: number | Animated.Value;
+  /**
+   * The angle of the point on the circle.
+   */
+  radians: number | Animated.Value;
+};
+
+/**
+ * Converts the polar co-ordinates of a point on a circle to its Cartesian co-ordinate,
+ * supporting `Animated.Value` for radius and/or radians.
+ * x = r cos θ, y = r sin θ
+ * @param props The property of the circle
+ * @param props.radius The radius of the circle. Can be a number or an `Animated.Value`.
+ * @param props.radians The angle of the point on the circle. Can be a number or an `Animated.Value`.
+ * @returns The Cartesian co-ordinates of the point of the circle, interpolated when animated.
+ * @throws {Error}  If neither `radius` nor `radians` is an `Animated.Value`. Use `pointOnCircle` for static values.
+ */
+export function pointOnCircleAnimated({
+  radians,
+  radius,
+}: PointOnCircleAnimated) {
+  if (typeof radians === 'number') {
+    if (typeof radius === 'number') {
+      throw new Error(
+        'At least one of radius and radians needs to be an Animated.Value.' +
+          ' Use pointOnCircle for static values.'
+      );
+    } else {
       return {
-        x: interpolationWithFunction(radius, (r) => Math.cos(radians) * r),
-        y: interpolationWithFunction(radius, (r) => Math.sin(radians) * r),
+        x: interpolationWithFunction(radius, (r) =>
+          pointOnCircleX({ radius: r, radians })
+        ),
+        y: interpolationWithFunction(radius, (r) =>
+          pointOnCircleY({ radius: r, radians })
+        ),
       };
     }
-
+  } else {
     return {
       x: Animated.multiply(
-        radius,
-        interpolationWithFunction(radians, (r) => Math.cos(r), {
-          endValue: 2 * Math.PI,
-        })
+        interpolationWithFunction(
+          radians,
+          (rad) => pointOnCircleX({ radius: 1, radians: rad }),
+          { endValue: 2 * Math.PI }
+        ),
+        radius
       ),
       y: Animated.multiply(
-        radius,
-        interpolationWithFunction(radians, (r) => Math.sin(r), {
-          endValue: 2 * Math.PI,
-        })
+        interpolationWithFunction(
+          radians,
+          (rad) => pointOnCircleY({ radius: 1, radians: rad }),
+          { endValue: 2 * Math.PI }
+        ),
+        radius
       ),
     };
   }
-
-  if (typeof radians !== 'number') {
-    return {
-      x: interpolationWithFunction(radians, (r) => Math.cos(r) * radius, {
-        endValue: 2 * Math.PI,
-      }),
-      y: interpolationWithFunction(radians, (r) => Math.sin(r) * radius, {
-        endValue: 2 * Math.PI,
-      }),
-    };
-  }
-
-  return {
-    x: Math.cos(radians) * radius,
-    y: Math.sin(radians) * radius,
-  };
-};
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,9 @@
 export { interpolationWithFunction } from './animation';
-export { pointOnCircle, pointOnCircleAnimated } from './circle';
+export {
+  getArcPath,
+  getSectorPath,
+  pointOnCircle,
+  pointOnCircleAnimated,
+} from './circle';
 export type { PointOnCircle, PointOnCircleAnimated } from './circle';
 export { validateProps } from './validation';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
 export { interpolationWithFunction } from './animation';
-export { pointOnCircle } from './circle';
-export type { PointOnCircle } from './circle';
+export { pointOnCircle, pointOnCircleAnimated } from './circle';
+export type { PointOnCircle, PointOnCircleAnimated } from './circle';
 export { validateProps } from './validation';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { interpolationWithFunction } from './animation';
 export { pointOnCircle } from './circle';
 export type { PointOnCircle } from './circle';
+export { validateProps } from './validation';

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,38 @@
+import type { CircleLayoutProps } from '../types';
+
+/**
+ * Validates the props passed to the CircleLayout component and
+ * returns the validated props. If any of the props are invalid, an error is thrown.
+ * @param props The properties passed to the component
+ * @returns The validated properties
+ */
+export function validateProps(props: CircleLayoutProps): CircleLayoutProps & {
+  sweepAngle: number;
+  startAngle: number;
+} {
+  const errors: string[] = [];
+  if (props.components.length < 2) {
+    errors.push('At least two components need to be passed to CircleLayout');
+  }
+  if (props.radius <= 0) {
+    errors.push('Radius needs to be greater than 0');
+  }
+
+  if (props.sweepAngle === 0) {
+    errors.push('Sweep angle cannot be 0');
+  }
+
+  if (errors.length > 0) {
+    throw new Error(errors.join('\n'));
+  }
+
+  return {
+    ...props,
+    sweepAngle: props.sweepAngle
+      ? props.sweepAngle % (2 * Math.PI) === 0
+        ? 2 * Math.PI
+        : props.sweepAngle % (2 * Math.PI)
+      : 2 * Math.PI,
+    startAngle: (props.startAngle ?? 0) % (2 * Math.PI),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds an SVG-based animated background (`bgConfig`) drawn as donut/sector shapes behind the circle's components, split into a `CircleLayoutProvider`/`CircleLayoutContent`/`Bg` architecture (was a single `CircleLayout`)
- Re-keys `animationProps.animationConfigs` from an array to `Partial<Record<AnimationType, AnimationConfig>>` and exposes `sectorAngle` on context
- Adds tests for the previously-uncovered `useAnimatedSectorPath` hook and the `bgConfig` render path (`Bg`/`CircleLayoutProvider`/`CircleLayoutContent`)
- Fixes doc drift: README's `AnimationProps`/`AnimationConfig`/`AnimationType` blocks described the old shape; AGENTS.md/ADR-0002 still showed the pre-split architecture and a stale `totalParts` file pointer
- Exports the previously-missing `BgConfig` type from the package entrypoint (it was referenced by `CircleLayoutProps.bgConfig` but unimportable) and fixes its `strokeColor` default doc to match actual fallback behavior
- Fixes `pnpm test` exiting non-zero despite all suites passing — pre-existing leaked `Animated.timing` timers fired after Jest tore the environment down and crashed the worker (`_bezier is not a function` / "environment torn down" `ReferenceError`s); reproducible on a clean checkout, unrelated to the feature work. Fixed via stopping the two animations that leak in `useAnimation.test.ts`, a `jest.setup.ts` that warms the lazily-loaded bezier easing curve, and `--forceExit` on the test script (composite show/hide animations build internal `sequence`/`parallel`/`delay` chains with no external handle to cancel)

## Test plan
- [x] `pnpm test` — 9/9 suites, 156/156 tests, exit 0
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] Manually rendered `CircleLayout` with `bgConfig` (color, innerRadius/outerRadius, show/hide via ref) under `@testing-library/react-native`

🤖 Generated with [Claude Code](https://claude.com/claude-code)