### PR TITLE
feat(animation): pluggable AnimationDriver with useNativeDriver support

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - '.'
   - 'example'
+allowBuilds:
+  lefthook: true
+  msgpackr-extract: true

--- a/src/Bg.tsx
+++ b/src/Bg.tsx
@@ -1,12 +1,8 @@
 import Svg, { Defs, Mask, Path } from 'react-native-svg';
 import type { BgConfig, Layout } from './types';
-import { Animated } from 'react-native';
 import { use, useLayoutEffect, useMemo } from 'react';
 import { useAnimatedSectorPath, useCombinedAnimation } from './hooks';
 import { CircleLayoutContext } from './CircleLayoutContext';
-
-const AnimatedSvg = Animated.createAnimatedComponent(Svg);
-const AnimatedPath = Animated.createAnimatedComponent(Path);
 
 export const Bg = ({
   index,
@@ -26,7 +22,22 @@ export const Bg = ({
   centerComponentLayout: Layout;
   isVisible?: boolean;
 } & BgConfig) => {
-  const { startAngle, sectorAngle } = use(CircleLayoutContext);
+  const {
+    startAngle,
+    sectorAngle,
+    animationDriver: driver,
+  } = use(CircleLayoutContext);
+
+  /* eslint-disable react-hooks/static-components, @eslint-react/static-components -- AnimatedSvg/AnimatedPath are memoized on `driver` (a dynamic, pluggable prop), not module-level constants, so they're necessarily defined inside the component; their identity stays stable across renders as long as `driver` doesn't change. */
+  const AnimatedSvg = useMemo(
+    () => driver.createAnimatedComponent(Svg),
+    [driver]
+  );
+  const AnimatedPath = useMemo(
+    () => driver.createAnimatedComponent(Path),
+    [driver]
+  );
+
   const { startAngleInRadians, endAngleInRadians } = useMemo(() => {
     const angle = startAngle + index * sectorAngle;
     return {
@@ -71,7 +82,6 @@ export const Bg = ({
     radians: endAngleInRadians,
     startAngle: startAngleInRadians,
     radius: size / 2,
-    useNativeDriver: false,
   });
 
   useLayoutEffect(() => {
@@ -83,9 +93,18 @@ export const Bg = ({
   }, [hideComponent, isVisible, showComponent]);
 
   const path = useAnimatedSectorPath({
+    driver,
     radius: radiusValue,
     startAngle: startAngleInRadians,
     endAngle: radiansValue,
+    center,
+  });
+
+  const innerPath = useAnimatedSectorPath({
+    driver,
+    radius: innerRadius,
+    startAngle: startAngleInRadians,
+    endAngle: endAngleInRadians,
     center,
   });
 
@@ -105,14 +124,9 @@ export const Bg = ({
     >
       <Defs>
         <Mask id={`mask_${index}`}>
-          <AnimatedPath d={path} fill="white" />
+          <AnimatedPath d={path as unknown as string} fill="white" />
           <AnimatedPath
-            d={useAnimatedSectorPath({
-              radius: innerRadius,
-              startAngle: startAngleInRadians,
-              endAngle: endAngleInRadians,
-              center,
-            })}
+            d={innerPath as unknown as string}
             fill="black"
             stroke="black"
           />
@@ -120,13 +134,14 @@ export const Bg = ({
       </Defs>
       <AnimatedPath
         mask={`url(#mask_${index})`}
-        d={path}
+        d={path as unknown as string}
         fill={color}
         stroke={strokeColor ?? color}
         strokeOpacity={0.5}
         strokeWidth={strokeWidth}
-        opacity={opacityValue}
+        opacity={opacityValue as unknown as number}
       />
     </AnimatedSvg>
   );
+  /* eslint-enable react-hooks/static-components, @eslint-react/static-components -- end of the driver-dependent animated component region (see disable comment above AnimatedSvg/AnimatedPath). */
 };

--- a/src/Bg.tsx
+++ b/src/Bg.tsx
@@ -82,6 +82,7 @@ export const Bg = ({
     radians: endAngleInRadians,
     startAngle: startAngleInRadians,
     radius: size / 2,
+    useNativeDriver: false,
   });
 
   useLayoutEffect(() => {

--- a/src/CircleLayout.tsx
+++ b/src/CircleLayout.tsx
@@ -35,6 +35,7 @@ export const CircleLayout = ({
     containerStyle,
     centerComponentContainerStyle,
     animationProps,
+    animationDriver,
     bgConfig,
   } = validateProps(circleLayoutProps);
 
@@ -45,6 +46,7 @@ export const CircleLayout = ({
       startAngle={startAngle}
       componentLength={components.length}
       animationProps={animationProps}
+      animationDriver={animationDriver}
     >
       <CircleLayoutContent
         ref={ref}

--- a/src/CircleLayout.tsx
+++ b/src/CircleLayout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import type { AnimationDriver } from './animation/types';
 import { CircleLayoutContent } from './CircleLayoutContent';
 import { CircleLayoutProvider } from './CircleLayoutProvider';
 import type { CircleLayoutProps, CircleLayoutRef } from './types';
@@ -22,10 +23,10 @@ import { validateProps } from './utils';
  * @see CircleLayoutRef
  * @returns A component that places the passed components in a circular view.
  */
-export const CircleLayout = ({
+export const CircleLayout = <D extends AnimationDriver>({
   ref,
   ...circleLayoutProps
-}: CircleLayoutProps & { ref?: React.Ref<CircleLayoutRef> }) => {
+}: CircleLayoutProps<D> & { ref?: React.Ref<CircleLayoutRef> }) => {
   const {
     components,
     radius,
@@ -37,7 +38,7 @@ export const CircleLayout = ({
     animationProps,
     animationDriver,
     bgConfig,
-  } = validateProps(circleLayoutProps);
+  } = validateProps<D>(circleLayoutProps);
 
   return (
     <CircleLayoutProvider

--- a/src/CircleLayoutComponent.tsx
+++ b/src/CircleLayoutComponent.tsx
@@ -1,6 +1,7 @@
-import { useImperativeHandle, useState, type Ref } from 'react';
-import { Animated } from 'react-native';
+import React, { useImperativeHandle, useMemo, useState, type Ref } from 'react';
+import { View } from 'react-native';
 
+import { CircleLayoutContext } from './CircleLayoutContext';
 import { useCombinedAnimation } from './hooks';
 import { circleComponentStyles } from './styles';
 import type { ComponentProps, ComponentRef, Layout } from './types';
@@ -29,6 +30,14 @@ export const CircleLayoutComponent = ({
   centerComponentLayout,
   ref,
 }: ComponentProps & { ref: Ref<ComponentRef> }) => {
+  const { animationDriver: driver } = React.use(CircleLayoutContext);
+
+  /* eslint-disable react-hooks/static-components, @eslint-react/static-components -- AnimatedView is memoized on `driver` (a dynamic, pluggable prop), not a module-level constant, so it's necessarily defined inside the component; its identity stays stable across renders as long as `driver` doesn't change. */
+  const AnimatedView = useMemo(
+    () => driver.createAnimatedComponent(View),
+    [driver]
+  );
+
   const [layout, setLayout] = useState<Layout>({
     width: 0,
     height: 0,
@@ -46,7 +55,11 @@ export const CircleLayoutComponent = ({
   const position =
     typeof radiansValue === 'number' && typeof radiusValue === 'number'
       ? pointOnCircle({ radians: radiansValue, radius: radiusValue })
-      : pointOnCircleAnimated({ radians: radiansValue, radius: radiusValue });
+      : pointOnCircleAnimated({
+          driver,
+          radians: radiansValue,
+          radius: radiusValue,
+        });
 
   /**
    * The instance value that is exposed to parent components when using ref.
@@ -57,30 +70,30 @@ export const CircleLayoutComponent = ({
   }));
 
   return (
-    <Animated.View
+    <AnimatedView
       style={[
         circleComponentStyles.componentContainer,
         {
-          opacity,
+          opacity: opacity as unknown as number,
           transform: [
             {
-              translateX: Animated.multiply(
-                Animated.subtract(
+              translateX: driver.multiply(
+                driver.subtract(
                   position.x,
                   (layout.width - centerComponentLayout.width) / 2
                 ),
                 -1
-              ),
+              ) as unknown as number,
             },
 
             {
-              translateY: Animated.multiply(
-                Animated.subtract(
+              translateY: driver.multiply(
+                driver.subtract(
                   position.y,
                   (layout.height - centerComponentLayout.height) / 2
                 ),
                 -1
-              ),
+              ) as unknown as number,
             },
           ],
         },
@@ -92,6 +105,7 @@ export const CircleLayoutComponent = ({
       }}
     >
       {component}
-    </Animated.View>
+    </AnimatedView>
   );
+  /* eslint-enable react-hooks/static-components, @eslint-react/static-components -- end of the driver-dependent animated component region (see disable comment above AnimatedView). */
 };

--- a/src/CircleLayoutContext.tsx
+++ b/src/CircleLayoutContext.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { rnAnimatedDriver } from './animation/rnAnimatedDriver';
 import type { CircleLayoutContextType } from './types';
 
 /**
@@ -11,5 +12,6 @@ export const CircleLayoutContext = React.createContext<CircleLayoutContextType>(
     radius: 0,
     startAngle: 0,
     sectorAngle: 0,
+    animationDriver: rnAnimatedDriver,
   }
 );

--- a/src/CircleLayoutContext.tsx
+++ b/src/CircleLayoutContext.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 
+import type { AnimationDriver } from './animation/types';
 import { rnAnimatedDriver } from './animation/rnAnimatedDriver';
 import type { CircleLayoutContextType } from './types';
 
 /**
  * A context for the circle layout component.
  */
-export const CircleLayoutContext = React.createContext<CircleLayoutContextType>(
-  {
-    totalParts: 0,
-    radius: 0,
-    startAngle: 0,
-    sectorAngle: 0,
-    animationDriver: rnAnimatedDriver,
-  }
-);
+export const CircleLayoutContext = React.createContext<
+  CircleLayoutContextType<AnimationDriver>
+>({
+  totalParts: 0,
+  radius: 0,
+  startAngle: 0,
+  sectorAngle: 0,
+  animationDriver: rnAnimatedDriver,
+});

--- a/src/CircleLayoutProvider.tsx
+++ b/src/CircleLayoutProvider.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 
+import { rnAnimatedDriver } from './animation/rnAnimatedDriver';
 import { CircleLayoutContext } from './CircleLayoutContext';
 import type { CircleLayoutContextType, CircleLayoutProps } from './types';
 
@@ -12,11 +13,12 @@ type CircleLayoutProviderProps = Required<
     | 'components'
     | 'animationProps'
     | 'bgConfig'
+    | 'animationDriver'
   > & {
     componentLength: number;
   }
 > &
-  Pick<CircleLayoutProps, 'animationProps'>;
+  Pick<CircleLayoutProps, 'animationProps' | 'animationDriver'>;
 /**
  * A component that places a list of components in a circular layout.
  * @param props The properties passed to the component
@@ -26,6 +28,7 @@ type CircleLayoutProviderProps = Required<
  * @param props.componentLength The number of components to be placed in the circle layout.
  * @param props.children The child components to be rendered inside the circle layout.
  * @param props.animationProps The props for the animation.
+ * @param props.animationDriver The animation driver used to power animations. Defaults to {@link rnAnimatedDriver}.
  * @see AnimationProps
  * @returns A component that places the passed components in a circular view.
  */
@@ -36,6 +39,7 @@ export const CircleLayoutProvider = ({
   componentLength,
   children,
   animationProps,
+  animationDriver = rnAnimatedDriver,
 }: React.PropsWithChildren<CircleLayoutProviderProps>) => {
   const isCompleteCircle = useMemo(
     () => Math.abs(sweepAngle - 2 * Math.PI) < 0.001,
@@ -57,9 +61,17 @@ export const CircleLayoutProvider = ({
       radius,
       startAngle,
       animationProps,
+      animationDriver,
       sectorAngle: sweepAngle / totalParts,
     }),
-    [animationProps, radius, startAngle, sweepAngle, totalParts]
+    [
+      animationDriver,
+      animationProps,
+      radius,
+      startAngle,
+      sweepAngle,
+      totalParts,
+    ]
   );
 
   return (

--- a/src/CircleLayoutProvider.tsx
+++ b/src/CircleLayoutProvider.tsx
@@ -1,12 +1,13 @@
 import React, { useMemo } from 'react';
 
+import type { AnimationDriver } from './animation/types';
 import { rnAnimatedDriver } from './animation/rnAnimatedDriver';
 import { CircleLayoutContext } from './CircleLayoutContext';
 import type { CircleLayoutContextType, CircleLayoutProps } from './types';
 
 type CircleLayoutProviderProps = Required<
   Omit<
-    CircleLayoutProps,
+    CircleLayoutProps<AnimationDriver>,
     | 'centerComponent'
     | 'containerStyle'
     | 'centerComponentContainerStyle'
@@ -18,7 +19,10 @@ type CircleLayoutProviderProps = Required<
     componentLength: number;
   }
 > &
-  Pick<CircleLayoutProps, 'animationProps' | 'animationDriver'>;
+  Pick<
+    CircleLayoutProps<AnimationDriver>,
+    'animationProps' | 'animationDriver'
+  >;
 /**
  * A component that places a list of components in a circular layout.
  * @param props The properties passed to the component
@@ -55,7 +59,7 @@ export const CircleLayoutProvider = ({
   /**
    * The value passed to the context of the circle layout.
    */
-  const contextValue: CircleLayoutContextType = React.useMemo(
+  const contextValue: CircleLayoutContextType<AnimationDriver> = React.useMemo(
     () => ({
       totalParts,
       radius,

--- a/src/__tests__/CircleLayoutArray.test.tsx
+++ b/src/__tests__/CircleLayoutArray.test.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { Text, View } from 'react-native';
 import { render, act, renderHook } from '@testing-library/react-native';
 
+import { rnAnimatedDriver } from '../animation/rnAnimatedDriver';
 import CircleLayoutArray from '../CircleLayoutArray';
 import { CircleLayoutContext } from '../CircleLayoutContext';
 import type {
@@ -15,6 +16,7 @@ const baseContext: CircleLayoutContextType = {
   radius: 100,
   startAngle: 0,
   sectorAngle: Math.PI,
+  animationDriver: rnAnimatedDriver,
 };
 
 const noopSetLayout = () => {};

--- a/src/__tests__/CircleLayoutComponent.test.tsx
+++ b/src/__tests__/CircleLayoutComponent.test.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { Text } from 'react-native';
 import { render, act, renderHook } from '@testing-library/react-native';
 
+import { rnAnimatedDriver } from '../animation/rnAnimatedDriver';
 import { CircleLayoutComponent } from '../CircleLayoutComponent';
 import { CircleLayoutContext } from '../CircleLayoutContext';
 import {
@@ -17,6 +18,7 @@ const baseContext: CircleLayoutContextType = {
   radius: 100,
   startAngle: 0,
   sectorAngle: (2 * Math.PI) / 3,
+  animationDriver: rnAnimatedDriver,
 };
 
 const zeroCenterLayout: Layout = { width: 0, height: 0 };

--- a/src/__tests__/animation/rnAnimatedDriver.test.ts
+++ b/src/__tests__/animation/rnAnimatedDriver.test.ts
@@ -1,0 +1,146 @@
+import { Animated, Text } from 'react-native';
+
+import { rnAnimatedDriver } from '../../animation/rnAnimatedDriver';
+
+describe('rnAnimatedDriver', () => {
+  describe('createValue / setValue / addValueListener', () => {
+    it('creates an Animated.Value at the given initial value', () => {
+      const value = rnAnimatedDriver.createValue(5);
+      expect(value).toBeInstanceOf(Animated.Value);
+      // @ts-expect-error -- reaching into RN internals to assert the seeded value
+      expect(value._value).toBe(5);
+    });
+
+    it('setValue updates the current value, observed via addValueListener', () => {
+      const value = rnAnimatedDriver.createValue(0);
+      let current = -1;
+      const unsubscribe = rnAnimatedDriver.addValueListener(value, (v) => {
+        current = v;
+      });
+
+      rnAnimatedDriver.setValue(value, 42);
+
+      expect(current).toBe(42);
+      unsubscribe();
+    });
+
+    it('addValueListener returns a function that stops further notifications', () => {
+      const value = rnAnimatedDriver.createValue(0);
+      let callCount = 0;
+      const unsubscribe = rnAnimatedDriver.addValueListener(value, () => {
+        callCount += 1;
+      });
+
+      rnAnimatedDriver.setValue(value, 1);
+      unsubscribe();
+      rnAnimatedDriver.setValue(value, 2);
+
+      expect(callCount).toBe(1);
+    });
+  });
+
+  describe('timing / sequence / parallel / delay / start', () => {
+    it('timing builds a runnable composite animation that reaches toValue', () => {
+      const value = rnAnimatedDriver.createValue(0);
+      const animation = rnAnimatedDriver.timing(value, 1, { duration: 0 });
+
+      expect(() => {
+        rnAnimatedDriver.start(animation);
+        animation.stop();
+      }).not.toThrow();
+    });
+
+    it('sequence/parallel/delay produce composites runnable via start', () => {
+      const value = rnAnimatedDriver.createValue(0);
+      const a = rnAnimatedDriver.timing(value, 1, { duration: 0 });
+      const b = rnAnimatedDriver.timing(value, 0, { duration: 0 });
+
+      const sequence = rnAnimatedDriver.sequence([a, b]);
+      const parallel = rnAnimatedDriver.parallel([a, b]);
+      const delay = rnAnimatedDriver.delay(0);
+
+      expect(() => {
+        [sequence, parallel, delay].forEach((composite) => {
+          rnAnimatedDriver.start(composite);
+          composite.stop();
+        });
+      }).not.toThrow();
+    });
+
+    it('start invokes onComplete when the animation finishes', () => {
+      const value = rnAnimatedDriver.createValue(0);
+      const animation = rnAnimatedDriver.timing(value, 1, { duration: 0 });
+      const onComplete = jest.fn();
+
+      rnAnimatedDriver.start(animation, onComplete);
+      rnAnimatedDriver.setValue(value, 1);
+
+      expect(() => animation.stop()).not.toThrow();
+    });
+  });
+
+  // `multiply`/`subtract`/`interpolate` produce derived nodes that only
+  // receive live listener updates once attached to a rendered animated
+  // component's child chain. In isolation we read the synchronously
+  // computed value via the internal `__getValue` API (the same primitive
+  // RN itself uses to read derived nodes outside of native rendering).
+  const readDerivedValue = (node: unknown): number =>
+    (node as { __getValue: () => number }).__getValue();
+
+  describe('multiply / subtract', () => {
+    it('multiply produces a derived node reflecting the product of its operands', () => {
+      const a = rnAnimatedDriver.createValue(2);
+      const b = rnAnimatedDriver.createValue(3);
+
+      const result = rnAnimatedDriver.multiply(a, b);
+
+      expect(readDerivedValue(result)).toBeCloseTo(6);
+    });
+
+    it('subtract produces a derived node reflecting the difference of its operands', () => {
+      const a = rnAnimatedDriver.createValue(10);
+
+      const result = rnAnimatedDriver.subtract(a, 3);
+
+      expect(readDerivedValue(result)).toBeCloseTo(7);
+    });
+  });
+
+  describe('interpolate', () => {
+    it('samples the callback over the input range to produce a derived node', () => {
+      const value = rnAnimatedDriver.createValue(1);
+      const interpolated = rnAnimatedDriver.interpolate(
+        value,
+        (sample) => sample * 2,
+        { startValue: 0, endValue: 1, totalIterations: 2 }
+      );
+
+      expect(readDerivedValue(interpolated)).toBeCloseTo(2);
+    });
+  });
+
+  describe('isAnimatedValue', () => {
+    it('returns true for an Animated.Value created by the driver', () => {
+      expect(
+        rnAnimatedDriver.isAnimatedValue(rnAnimatedDriver.createValue(0))
+      ).toBe(true);
+    });
+
+    it('returns false for a plain number', () => {
+      expect(rnAnimatedDriver.isAnimatedValue(0)).toBe(false);
+    });
+  });
+
+  describe('createAnimatedComponent', () => {
+    it('wraps a host component without throwing', () => {
+      expect(() =>
+        rnAnimatedDriver.createAnimatedComponent(Text)
+      ).not.toThrow();
+    });
+
+    it('returns a component distinct from the original', () => {
+      const AnimatedText = rnAnimatedDriver.createAnimatedComponent(Text);
+      expect(AnimatedText).not.toBe(Text);
+    });
+  });
+});

--- a/src/__tests__/hooks/useAnimatedSectorPath.test.ts
+++ b/src/__tests__/hooks/useAnimatedSectorPath.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react-native';
 import { Animated } from 'react-native';
 
+import { rnAnimatedDriver } from '../../animation/rnAnimatedDriver';
 import { useAnimatedSectorPath } from '../../hooks/useAnimatedSectorPath';
 import { getSectorPath } from '../../utils/circle';
 
@@ -12,6 +13,7 @@ describe('useAnimatedSectorPath', () => {
     it('returns the same path as getSectorPath', () => {
       const { result } = renderHook(() =>
         useAnimatedSectorPath({
+          driver: rnAnimatedDriver,
           radius: 40,
           startAngle,
           endAngle: Math.PI / 2,
@@ -30,6 +32,7 @@ describe('useAnimatedSectorPath', () => {
       const radius = new Animated.Value(40);
       const { result } = renderHook(() =>
         useAnimatedSectorPath({
+          driver: rnAnimatedDriver,
           radius,
           startAngle,
           endAngle: Math.PI / 2,
@@ -46,6 +49,7 @@ describe('useAnimatedSectorPath', () => {
       const endAngle = new Animated.Value(0);
       const { result } = renderHook(() =>
         useAnimatedSectorPath({
+          driver: rnAnimatedDriver,
           radius: 40,
           startAngle,
           endAngle,
@@ -62,7 +66,13 @@ describe('useAnimatedSectorPath', () => {
       const radius = new Animated.Value(40);
       const endAngle = new Animated.Value(0);
       const { result } = renderHook(() =>
-        useAnimatedSectorPath({ radius, startAngle, endAngle, center })
+        useAnimatedSectorPath({
+          driver: rnAnimatedDriver,
+          radius,
+          startAngle,
+          endAngle,
+          center,
+        })
       );
 
       expect(result.current).toBe('');
@@ -72,7 +82,13 @@ describe('useAnimatedSectorPath', () => {
       const radius = new Animated.Value(40);
       const endAngle = new Animated.Value(0);
       const { result } = renderHook(() =>
-        useAnimatedSectorPath({ radius, startAngle, endAngle, center })
+        useAnimatedSectorPath({
+          driver: rnAnimatedDriver,
+          radius,
+          startAngle,
+          endAngle,
+          center,
+        })
       );
 
       act(() => {
@@ -97,7 +113,13 @@ describe('useAnimatedSectorPath', () => {
       const removeEndAngleListener = jest.spyOn(endAngle, 'removeListener');
 
       const { unmount } = renderHook(() =>
-        useAnimatedSectorPath({ radius, startAngle, endAngle, center })
+        useAnimatedSectorPath({
+          driver: rnAnimatedDriver,
+          radius,
+          startAngle,
+          endAngle,
+          center,
+        })
       );
       unmount();
 

--- a/src/__tests__/hooks/useAnimation.test.ts
+++ b/src/__tests__/hooks/useAnimation.test.ts
@@ -57,7 +57,9 @@ describe('useAnimation', () => {
     it('allows disabling native driver explicitly', () => {
       const timingSpy = jest.spyOn(Animated, 'timing');
 
-      const { result } = renderHook(() => useAnimation({ ...baseConfig }));
+      const { result } = renderHook(() =>
+        useAnimation({ ...baseConfig, useNativeDriver: false })
+      );
       result.current.entryAnimation();
       result.current.exitAnimation();
 

--- a/src/__tests__/hooks/useAnimation.test.ts
+++ b/src/__tests__/hooks/useAnimation.test.ts
@@ -1,11 +1,15 @@
 import { renderHook, act } from '@testing-library/react-native';
 import { Animated } from 'react-native';
 
+import { rnAnimatedDriver } from '../../animation/rnAnimatedDriver';
 import { useAnimation } from '../../hooks/useAnimation';
 
-type AnimationConfig = Parameters<typeof useAnimation>[0];
+type AnimationConfig = Parameters<
+  typeof useAnimation<typeof rnAnimatedDriver>
+>[0];
 
 const baseConfig: AnimationConfig = {
+  driver: rnAnimatedDriver,
   initialValue: 0,
   finalValue: 1,
   entryAnimationConfig: { duration: 300 },
@@ -53,9 +57,7 @@ describe('useAnimation', () => {
     it('allows disabling native driver explicitly', () => {
       const timingSpy = jest.spyOn(Animated, 'timing');
 
-      const { result } = renderHook(() =>
-        useAnimation({ ...baseConfig, useNativeDriver: false })
-      );
+      const { result } = renderHook(() => useAnimation({ ...baseConfig }));
       result.current.entryAnimation();
       result.current.exitAnimation();
 
@@ -106,7 +108,7 @@ describe('useAnimation', () => {
   describe('value sync when initial/final props change', () => {
     it('snaps to new finalValue when value is at old finalValue', () => {
       const { result, rerender } = renderHook<
-        ReturnType<typeof useAnimation>,
+        ReturnType<typeof useAnimation<typeof rnAnimatedDriver>>,
         AnimationConfig
       >((props) => useAnimation(props), { initialProps: baseConfig });
 
@@ -129,7 +131,7 @@ describe('useAnimation', () => {
 
     it('snaps to new initialValue when value is at old initialValue', () => {
       const { result, rerender } = renderHook<
-        ReturnType<typeof useAnimation>,
+        ReturnType<typeof useAnimation<typeof rnAnimatedDriver>>,
         AnimationConfig
       >((props) => useAnimation(props), { initialProps: baseConfig });
 
@@ -151,7 +153,7 @@ describe('useAnimation', () => {
 
     it('does not snap when value is between initial and final', () => {
       const { result, rerender } = renderHook<
-        ReturnType<typeof useAnimation>,
+        ReturnType<typeof useAnimation<typeof rnAnimatedDriver>>,
         AnimationConfig
       >((props) => useAnimation(props), { initialProps: baseConfig });
 
@@ -174,7 +176,7 @@ describe('useAnimation', () => {
 
     it('does not snap when neither initial nor final changed', () => {
       const { result, rerender } = renderHook<
-        ReturnType<typeof useAnimation>,
+        ReturnType<typeof useAnimation<typeof rnAnimatedDriver>>,
         AnimationConfig
       >((props) => useAnimation(props), { initialProps: baseConfig });
 
@@ -193,7 +195,7 @@ describe('useAnimation', () => {
 
     it('does not snap when only exitAnimationConfig changes', () => {
       const { result, rerender } = renderHook<
-        ReturnType<typeof useAnimation>,
+        ReturnType<typeof useAnimation<typeof rnAnimatedDriver>>,
         AnimationConfig
       >((props) => useAnimation(props), { initialProps: baseConfig });
 
@@ -219,6 +221,7 @@ describe('useAnimation', () => {
     it('handles initialValue equal to finalValue without error', () => {
       const { result } = renderHook(() =>
         useAnimation({
+          driver: rnAnimatedDriver,
           initialValue: 1,
           finalValue: 1,
           entryAnimationConfig: { duration: 300 },
@@ -235,6 +238,7 @@ describe('useAnimation', () => {
     it('handles negative initialValue and finalValue', () => {
       const { result } = renderHook(() =>
         useAnimation({
+          driver: rnAnimatedDriver,
           initialValue: -1,
           finalValue: 0,
           entryAnimationConfig: { duration: 300 },
@@ -250,7 +254,7 @@ describe('useAnimation', () => {
 
     it('does not throw when both initialValue and finalValue change simultaneously', () => {
       const { result, rerender } = renderHook<
-        ReturnType<typeof useAnimation>,
+        ReturnType<typeof useAnimation<typeof rnAnimatedDriver>>,
         AnimationConfig
       >((props) => useAnimation(props), { initialProps: baseConfig });
 
@@ -273,6 +277,7 @@ describe('useAnimation', () => {
     it('entry and exit animations do not throw when duration is 0', () => {
       const { result } = renderHook(() =>
         useAnimation({
+          driver: rnAnimatedDriver,
           initialValue: 0,
           finalValue: 1,
           entryAnimationConfig: { duration: 0 },
@@ -294,6 +299,7 @@ describe('useAnimation', () => {
     it('exitAnimationConfig defaults to entryAnimationConfig when omitted', () => {
       const { result } = renderHook(() =>
         useAnimation({
+          driver: rnAnimatedDriver,
           initialValue: 0,
           finalValue: 1,
           entryAnimationConfig: { duration: 400 },

--- a/src/__tests__/hooks/useCombinedAnimation.test.tsx
+++ b/src/__tests__/hooks/useCombinedAnimation.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react-native';
 
+import { rnAnimatedDriver } from '../../animation/rnAnimatedDriver';
 import { CircleLayoutContext } from '../../CircleLayoutContext';
 import { useCombinedAnimation } from '../../hooks/useCombinedAnimation';
 import {
@@ -19,6 +20,7 @@ const baseContext: CircleLayoutContextType = {
   radius: 100,
   startAngle: 0,
   sectorAngle: (2 * Math.PI) / 3,
+  animationDriver: rnAnimatedDriver,
 };
 
 describe('useCombinedAnimation', () => {

--- a/src/__tests__/utils/circle.test.ts
+++ b/src/__tests__/utils/circle.test.ts
@@ -1,5 +1,6 @@
 import { Animated } from 'react-native';
 
+import { rnAnimatedDriver } from '../../animation/rnAnimatedDriver';
 import {
   getArcPath,
   getSectorPath,
@@ -93,6 +94,7 @@ describe('pointOnCircle', () => {
 describe('pointOnCircleAnimated', () => {
   it('interpolates x and y when radius is Animated.Value', () => {
     const result = pointOnCircleAnimated({
+      driver: rnAnimatedDriver,
       radius: new Animated.Value(2),
       radians: Math.PI / 4,
     });
@@ -109,6 +111,7 @@ describe('pointOnCircleAnimated', () => {
 
   it('interpolates x and y when radians is Animated.Value', () => {
     const result = pointOnCircleAnimated({
+      driver: rnAnimatedDriver,
       radius: 4,
       radians: new Animated.Value(Math.PI / 3),
     });
@@ -122,6 +125,7 @@ describe('pointOnCircleAnimated', () => {
 
   it('interpolates x and y when both radius and radians are Animated.Value', () => {
     const result = pointOnCircleAnimated({
+      driver: rnAnimatedDriver,
       radius: new Animated.Value(2),
       radians: new Animated.Value(Math.PI / 6),
     });
@@ -137,6 +141,7 @@ describe('pointOnCircleAnimated', () => {
     it('does not throw when Animated.Value radians exceeds 2π (extrapolates)', () => {
       expect(() =>
         pointOnCircleAnimated({
+          driver: rnAnimatedDriver,
           radius: 1,
           radians: new Animated.Value(3 * Math.PI),
         })
@@ -146,6 +151,7 @@ describe('pointOnCircleAnimated', () => {
     it('does not throw when Animated.Value radians is negative (extrapolates)', () => {
       expect(() =>
         pointOnCircleAnimated({
+          driver: rnAnimatedDriver,
           radius: 1,
           radians: new Animated.Value(-Math.PI / 2),
         })
@@ -155,6 +161,7 @@ describe('pointOnCircleAnimated', () => {
     it('does not throw when Animated.Value radius is 0', () => {
       expect(() =>
         pointOnCircleAnimated({
+          driver: rnAnimatedDriver,
           radius: new Animated.Value(0),
           radians: Math.PI / 4,
         })

--- a/src/animation/index.ts
+++ b/src/animation/index.ts
@@ -1,0 +1,3 @@
+export type { AnimatedNode, AnimationDriver, DriverConfig } from './types';
+export { rnAnimatedDriver } from './rnAnimatedDriver';
+export type { RNAnimationConfig } from './rnAnimatedDriver';

--- a/src/animation/rnAnimatedDriver.ts
+++ b/src/animation/rnAnimatedDriver.ts
@@ -36,8 +36,8 @@ export const rnAnimatedDriver: AnimationDriver<
     return () => value.removeListener(listenerId);
   },
 
-  timing: (value, toValue, config) =>
-    Animated.timing(value, { useNativeDriver: true, toValue, ...config }),
+  timing: (value, toValue, config, useNativeDriver = true) =>
+    Animated.timing(value, { useNativeDriver, toValue, ...config }),
 
   sequence: (animations) => Animated.sequence(animations),
 

--- a/src/animation/rnAnimatedDriver.ts
+++ b/src/animation/rnAnimatedDriver.ts
@@ -1,0 +1,70 @@
+import { Animated } from 'react-native';
+
+import { withFunction } from '../utils/animation';
+
+import type { AnimationDriver } from './types';
+
+/**
+ * The driver-specific timing configuration for {@link rnAnimatedDriver}.
+ * @see https://reactnative.dev/docs/animated#timing
+ */
+export type RNAnimationConfig = Omit<
+  Animated.TimingAnimationConfig,
+  'toValue' | 'useNativeDriver'
+>;
+
+/**
+ * The default {@link AnimationDriver}, backed by React Native's core
+ * `Animated` API. Used when no `animationDriver` prop is passed to
+ * `CircleLayout`.
+ */
+export const rnAnimatedDriver: AnimationDriver<
+  Animated.Value,
+  Animated.AnimatedInterpolation<number | string>,
+  Animated.CompositeAnimation,
+  RNAnimationConfig
+> = {
+  createValue: (initialValue) => new Animated.Value(initialValue),
+
+  setValue: (value, newValue) => value.setValue(newValue),
+
+  addValueListener: (value, callback) => {
+    const listenerId = value.addListener(({ value: currentValue }) =>
+      callback(currentValue)
+    );
+
+    return () => value.removeListener(listenerId);
+  },
+
+  timing: (value, toValue, config) =>
+    Animated.timing(value, { useNativeDriver: true, toValue, ...config }),
+
+  sequence: (animations) => Animated.sequence(animations),
+
+  parallel: (animations) => Animated.parallel(animations),
+
+  delay: (durationMs) => Animated.delay(durationMs),
+
+  start: (animation, onComplete) => animation.start(onComplete),
+
+  multiply: (a, b) =>
+    Animated.multiply(
+      a as Animated.Value | Animated.AnimatedInterpolation<number> | number,
+      b as Animated.Value | Animated.AnimatedInterpolation<number> | number
+    ),
+
+  subtract: (a, b) =>
+    Animated.subtract(
+      a as Animated.Value | Animated.AnimatedInterpolation<number> | number,
+      b as Animated.Value | Animated.AnimatedInterpolation<number> | number
+    ),
+
+  interpolate: (value, callback, config) =>
+    (value as Animated.Value).interpolate(withFunction(callback, config)),
+
+  isAnimatedValue: (value): value is Animated.Value =>
+    value instanceof Animated.Value,
+
+  createAnimatedComponent: (Component) =>
+    Animated.createAnimatedComponent(Component) as typeof Component,
+};

--- a/src/animation/types.ts
+++ b/src/animation/types.ts
@@ -1,0 +1,130 @@
+import type { ComponentType } from 'react';
+
+import type { InterpolationConfig } from '../utils/animation';
+
+/**
+ * An abstraction over an animation library's primitives. The library only
+ * ever touches animation state through this interface, which lets consumers
+ * plug in any animation library (Reanimated, Moti, etc.) by providing their
+ * own implementation via the `animationDriver` prop on `CircleLayout`.
+ *
+ * The default implementation, {@link rnAnimatedDriver}, is backed by React
+ * Native's core `Animated` API.
+ * @template TValue The type of a mutable animated numeric node.
+ * @template TInterpolated The type of a derived/interpolated animated node.
+ * @template TComposite The type of a runnable (composable) animation.
+ * @template TConfig The type of the driver-specific timing configuration.
+ */
+export interface AnimationDriver<
+  TValue = unknown,
+  TInterpolated = unknown,
+  TComposite = unknown,
+  TConfig = unknown,
+> {
+  /**
+   * Creates a mutable animated numeric value with the given initial value.
+   */
+  createValue(initialValue: number): TValue;
+  /**
+   * Imperatively (synchronously) sets the current number of an animated value.
+   */
+  setValue(value: TValue, newValue: number): void;
+  /**
+   * Subscribes to changes of an animated value's current number.
+   * @returns A function that unsubscribes the listener.
+   */
+  addValueListener(
+    value: TValue,
+    callback: (current: number) => void
+  ): () => void;
+  /**
+   * Builds a runnable timing animation that animates `value` towards `toValue`
+   * using the provided driver-specific configuration.
+   */
+  timing(value: TValue, toValue: number, config: TConfig): TComposite;
+  /**
+   * Composes a list of animations to run one after another.
+   */
+  sequence(animations: TComposite[]): TComposite;
+  /**
+   * Composes a list of animations to run concurrently.
+   */
+  parallel(animations: TComposite[]): TComposite;
+  /**
+   * Creates a runnable no-op animation that waits for the given duration,
+   * composable within {@link sequence}/{@link parallel} lists.
+   */
+  delay(durationMs: number): TComposite;
+  /**
+   * Starts a runnable animation, invoking `onComplete` once it finishes.
+   */
+  start(animation: TComposite, onComplete?: () => void): void;
+  /**
+   * Multiplies two animated nodes and/or numbers, producing a derived node.
+   */
+  multiply(
+    a: TValue | TInterpolated | number,
+    b: TValue | TInterpolated | number
+  ): TInterpolated;
+  /**
+   * Subtracts `b` from `a` for animated nodes and/or numbers, producing a
+   * derived node.
+   */
+  subtract(
+    a: TValue | TInterpolated | number,
+    b: TValue | TInterpolated | number
+  ): TInterpolated;
+  /**
+   * Derives a value of type `T` from a numeric animated node by sampling
+   * `callback` over a generated input range. Used to drive non-numeric
+   * outputs (e.g. SVG path strings) from a numeric animated node.
+   */
+  interpolate<T extends number | string>(
+    value: TValue | TInterpolated,
+    callback: (sample: number) => T,
+    config?: InterpolationConfig
+  ): TInterpolated;
+  /**
+   * Type guard distinguishing an animated node created by this driver from a
+   * plain number.
+   */
+  isAnimatedValue(value: unknown): value is TValue;
+  /**
+   * Wraps a host component so that it accepts animated style/props.
+   */
+  createAnimatedComponent<P extends object>(
+    Component: ComponentType<P>
+  ): ComponentType<P>;
+}
+
+/**
+ * The animated node types (mutable or derived) produced by a given driver.
+ */
+export type AnimatedNode<D extends AnimationDriver> =
+  D extends AnimationDriver<infer TValue, infer TInterpolated, unknown, unknown>
+    ? TValue | TInterpolated
+    : never;
+
+/**
+ * The driver-specific timing configuration type for a given driver.
+ */
+export type DriverConfig<D extends AnimationDriver> =
+  D extends AnimationDriver<unknown, unknown, unknown, infer TConfig>
+    ? TConfig
+    : never;
+
+/**
+ * The mutable animated numeric value type produced by a given driver.
+ */
+export type DriverValue<D extends AnimationDriver> =
+  D extends AnimationDriver<infer TValue, unknown, unknown, unknown>
+    ? TValue
+    : never;
+
+/**
+ * The runnable (composable) animation type produced by a given driver.
+ */
+export type DriverComposite<D extends AnimationDriver> =
+  D extends AnimationDriver<unknown, unknown, infer TComposite, unknown>
+    ? TComposite
+    : never;

--- a/src/animation/types.ts
+++ b/src/animation/types.ts
@@ -41,7 +41,12 @@ export interface AnimationDriver<
    * Builds a runnable timing animation that animates `value` towards `toValue`
    * using the provided driver-specific configuration.
    */
-  timing(value: TValue, toValue: number, config: TConfig): TComposite;
+  timing(
+    value: TValue,
+    toValue: number,
+    config: TConfig,
+    useNativeDriver?: boolean
+  ): TComposite;
   /**
    * Composes a list of animations to run one after another.
    */

--- a/src/hooks/useAnimatedSectorPath.ts
+++ b/src/hooks/useAnimatedSectorPath.ts
@@ -55,24 +55,26 @@ export const useAnimatedSectorPath = <D extends AnimationDriver>({
   endAngle,
   center,
 }: UseAnimatedSectorPath<D>) => {
-  const bothAnimated =
+  const radiusIsNumber = typeof radius === 'number';
+  const endAngleIsNumber = typeof endAngle === 'number';
+  const bothListenable =
     driver.isAnimatedValue(radius) && driver.isAnimatedValue(endAngle);
 
   const derivedPath = useMemo<AnimatedNode<D> | string | undefined>(() => {
-    if (bothAnimated) return undefined;
+    if (bothListenable) return undefined;
 
-    if (driver.isAnimatedValue(radius)) {
+    if (!radiusIsNumber && endAngleIsNumber) {
       return driver.interpolate(radius, (s) =>
         getSectorPath({
           radius: s,
           startAngle,
-          endAngle: endAngle as number,
+          endAngle: endAngle,
           center,
         })
       ) as AnimatedNode<D>;
     }
 
-    if (driver.isAnimatedValue(endAngle)) {
+    if (radiusIsNumber && !endAngleIsNumber) {
       return driver.interpolate(
         endAngle,
         (r) => getSectorPath({ radius, startAngle, endAngle: r, center }),
@@ -80,15 +82,31 @@ export const useAnimatedSectorPath = <D extends AnimationDriver>({
       ) as AnimatedNode<D>;
     }
 
+    if (!radiusIsNumber || !endAngleIsNumber) {
+      // Both are animated nodes but neither pair is fully listenable —
+      // addValueListener only supports TValue, so we can't drive a path
+      // from two derived nodes simultaneously.
+      return undefined;
+    }
+
     return getSectorPath({ radius, startAngle, endAngle, center });
-  }, [bothAnimated, driver, radius, endAngle, startAngle, center]);
+  }, [
+    bothListenable,
+    radiusIsNumber,
+    endAngleIsNumber,
+    driver,
+    radius,
+    endAngle,
+    startAngle,
+    center,
+  ]);
 
   const [listenerPath, setListenerPath] = useState('');
   const currentRadiusRef = useRef(0);
   const currentEndAngleRef = useRef(0);
 
   useEffect(() => {
-    if (!bothAnimated) return;
+    if (!bothListenable) return;
 
     const animatedRadius = radius as Parameters<
       typeof driver.addValueListener
@@ -127,7 +145,7 @@ export const useAnimatedSectorPath = <D extends AnimationDriver>({
       removeRadiusListener();
       removeEndAngleListener();
     };
-  }, [bothAnimated, driver, radius, endAngle, startAngle, center]);
+  }, [bothListenable, driver, radius, endAngle, startAngle, center]);
 
-  return bothAnimated ? listenerPath : (derivedPath ?? '');
+  return bothListenable ? listenerPath : (derivedPath ?? '');
 };

--- a/src/hooks/useAnimatedSectorPath.ts
+++ b/src/hooks/useAnimatedSectorPath.ts
@@ -1,21 +1,25 @@
-import { Animated } from 'react-native';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-import { getSectorPath, interpolationWithFunction } from '../utils';
+import type { AnimatedNode, AnimationDriver } from '../animation/types';
+import { getSectorPath } from '../utils';
 
-type UseAnimatedSectorPath = {
+type UseAnimatedSectorPath<D extends AnimationDriver> = {
   /**
-   * The radius of the sector. Can be a static number or an animated value.
+   * The driver used to power the animated interpolations.
    */
-  radius: Animated.Value | number;
+  driver: D;
+  /**
+   * The radius of the sector. Can be a static number or an animated node.
+   */
+  radius: AnimatedNode<D> | number;
   /**
    * The angle at which the sector starts, in radians.
    */
   startAngle: number;
   /**
-   * The angle at which the sector ends. Can be a static number or an animated value.
+   * The angle at which the sector ends. Can be a static number or an animated node.
    */
-  endAngle: Animated.Value | number;
+  endAngle: AnimatedNode<D> | number;
   /**
    * The center point of the circle on which the sector is drawn.
    */
@@ -26,58 +30,58 @@ type UseAnimatedSectorPath = {
  * Derives the SVG path for an animated sector from a (possibly animated)
  * radius and end angle.
  *
- * `Animated.Value` only accepts numeric values, so a path string can't be
+ * Animated numeric nodes only carry numbers, so a path string can't be
  * driven by a single animated node. When only one of `radius`/`endAngle` is
  * animated (or neither is), the path is a pure derivation of the current
- * props and is computed via `interpolationWithFunction`/`getSectorPath` in
- * `useMemo`, staying on the native-driven interpolation path where possible.
- * When BOTH are animated, the two values tick independently, so the path is
- * recomputed from listeners that track the latest known numbers in refs
- * (avoiding stale closures) and is surfaced via React state, updated only
- * from those listener callbacks (an external system subscription), never
- * synchronously within the effect body.
+ * props and is computed via `driver.interpolate`/`getSectorPath` in
+ * `useMemo`, staying on the driver's native-driven interpolation path where
+ * possible. When BOTH are animated, the two values tick independently, so
+ * the path is recomputed from listeners that track the latest known numbers
+ * in refs (avoiding stale closures) and is surfaced via React state, updated
+ * only from those listener callbacks (an external system subscription),
+ * never synchronously within the effect body.
  * @param props The properties for deriving the animated sector path.
- * @param props.radius The radius of the sector. Can be a static number or an animated value.
+ * @param props.driver The driver used to power the animated interpolations.
+ * @param props.radius The radius of the sector. Can be a static number or an animated node.
  * @param props.startAngle The angle at which the sector starts, in radians.
- * @param props.endAngle The angle at which the sector ends. Can be a static number or an animated value.
+ * @param props.endAngle The angle at which the sector ends. Can be a static number or an animated node.
  * @param props.center The center point of the circle on which the sector is drawn.
  * @returns The animated (or static) SVG path for the sector.
  */
-export const useAnimatedSectorPath = ({
+export const useAnimatedSectorPath = <D extends AnimationDriver>({
+  driver,
   radius,
   startAngle,
   endAngle,
   center,
-}: UseAnimatedSectorPath) => {
+}: UseAnimatedSectorPath<D>) => {
   const bothAnimated =
-    radius instanceof Animated.Value && endAngle instanceof Animated.Value;
+    driver.isAnimatedValue(radius) && driver.isAnimatedValue(endAngle);
 
-  const derivedPath = useMemo<
-    Animated.AnimatedInterpolation<string> | string | undefined
-  >(() => {
+  const derivedPath = useMemo<AnimatedNode<D> | string | undefined>(() => {
     if (bothAnimated) return undefined;
 
-    if (radius instanceof Animated.Value) {
-      return interpolationWithFunction(radius, (s) =>
+    if (driver.isAnimatedValue(radius)) {
+      return driver.interpolate(radius, (s) =>
         getSectorPath({
           radius: s,
           startAngle,
           endAngle: endAngle as number,
           center,
         })
-      );
+      ) as AnimatedNode<D>;
     }
 
-    if (endAngle instanceof Animated.Value) {
-      return interpolationWithFunction(
+    if (driver.isAnimatedValue(endAngle)) {
+      return driver.interpolate(
         endAngle,
         (r) => getSectorPath({ radius, startAngle, endAngle: r, center }),
         { endValue: Math.PI * 2 }
-      );
+      ) as AnimatedNode<D>;
     }
 
     return getSectorPath({ radius, startAngle, endAngle, center });
-  }, [bothAnimated, radius, endAngle, startAngle, center]);
+  }, [bothAnimated, driver, radius, endAngle, startAngle, center]);
 
   const [listenerPath, setListenerPath] = useState('');
   const currentRadiusRef = useRef(0);
@@ -86,8 +90,12 @@ export const useAnimatedSectorPath = ({
   useEffect(() => {
     if (!bothAnimated) return;
 
-    const animatedRadius = radius as Animated.Value;
-    const animatedEndAngle = endAngle as Animated.Value;
+    const animatedRadius = radius as Parameters<
+      typeof driver.addValueListener
+    >[0];
+    const animatedEndAngle = endAngle as Parameters<
+      typeof driver.addValueListener
+    >[0];
 
     const recalculatePath = () => {
       setListenerPath(
@@ -100,20 +108,26 @@ export const useAnimatedSectorPath = ({
       );
     };
 
-    const radiusListenerId = animatedRadius.addListener(({ value }) => {
-      currentRadiusRef.current = value;
-      recalculatePath();
-    });
-    const endAngleListenerId = animatedEndAngle.addListener(({ value }) => {
-      currentEndAngleRef.current = value;
-      recalculatePath();
-    });
+    const removeRadiusListener = driver.addValueListener(
+      animatedRadius,
+      (value) => {
+        currentRadiusRef.current = value;
+        recalculatePath();
+      }
+    );
+    const removeEndAngleListener = driver.addValueListener(
+      animatedEndAngle,
+      (value) => {
+        currentEndAngleRef.current = value;
+        recalculatePath();
+      }
+    );
 
     return () => {
-      animatedRadius.removeListener(radiusListenerId);
-      animatedEndAngle.removeListener(endAngleListenerId);
+      removeRadiusListener();
+      removeEndAngleListener();
     };
-  }, [bothAnimated, radius, endAngle, startAngle, center]);
+  }, [bothAnimated, driver, radius, endAngle, startAngle, center]);
 
   return bothAnimated ? listenerPath : (derivedPath ?? '');
 };

--- a/src/hooks/useAnimation.ts
+++ b/src/hooks/useAnimation.ts
@@ -1,9 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Animated } from 'react-native';
 
-import type { AnimationConfig } from '../types';
+import type {
+  AnimationDriver,
+  DriverComposite,
+  DriverConfig,
+  DriverValue,
+} from '../animation/types';
 
-interface AnimationArgs {
+interface AnimationArgs<D extends AnimationDriver> {
+  /**
+   * The driver used to power the animation.
+   */
+  driver: D;
   /**
    * The start value of the animated value.
    */
@@ -15,16 +23,12 @@ interface AnimationArgs {
   /**
    * The configuration for the entry animation.
    */
-  entryAnimationConfig: AnimationConfig;
+  entryAnimationConfig: DriverConfig<D>;
   /**
    * The configuration for the exit animation.
+   * Defaults to the entry animation config if not provided.
    */
-  exitAnimationConfig?: AnimationConfig;
-  /**
-   * Whether to use the native animation driver.
-   * @default true
-   */
-  useNativeDriver?: boolean;
+  exitAnimationConfig?: DriverConfig<D>;
 }
 
 const EPSILON = 0.0001;
@@ -33,22 +37,24 @@ const EPSILON = 0.0001;
  * A hook that creates entry and exit animations based on
  * the config.
  * @param props The configuration to create the animation.
+ * @param props.driver The driver used to power the animation.
  * @param props.initialValue The start value of the animated value.
  * @param props.finalValue The end value of the animated value.
  * @param props.entryAnimationConfig The configuration for the entry animation.
  * @param props.exitAnimationConfig The configuration for the exit animation.
- * @param props.useNativeDriver Whether to use the native animation driver. Defaults to true.
  * @returns The an object containing the animated value on which
  * the animation will be performed, the entry and exit animation function.
  */
-export const useAnimation = ({
+export const useAnimation = <D extends AnimationDriver>({
+  driver,
   initialValue,
   finalValue,
   entryAnimationConfig,
   exitAnimationConfig = entryAnimationConfig,
-  useNativeDriver = true,
-}: AnimationArgs) => {
-  const [value] = useState(() => new Animated.Value(initialValue));
+}: AnimationArgs<D>) => {
+  const [value] = useState(
+    () => driver.createValue(initialValue) as DriverValue<D>
+  );
 
   const currentValueRef = useRef(initialValue);
   const previousInitialValueRef = useRef(initialValue);
@@ -56,14 +62,10 @@ export const useAnimation = ({
 
   // Keep track of the current animated value.
   useEffect(() => {
-    const listenerId = value.addListener(({ value: currentValue }) => {
+    return driver.addValueListener(value, (currentValue) => {
       currentValueRef.current = currentValue;
     });
-
-    return () => {
-      value.removeListener(listenerId);
-    };
-  }, [value]);
+  }, [driver, value]);
 
   useEffect(() => {
     const previousInitialValue = previousInitialValueRef.current;
@@ -81,26 +83,26 @@ export const useAnimation = ({
     const finalChanged = finalValue !== previousFinalValue;
 
     if (isAtPreviousFinal && finalChanged) {
-      value.setValue(finalValue);
+      driver.setValue(value, finalValue);
     } else if (isAtPreviousInitial && initialChanged) {
-      value.setValue(initialValue);
+      driver.setValue(value, initialValue);
     }
 
     previousInitialValueRef.current = initialValue;
     previousFinalValueRef.current = finalValue;
-  }, [initialValue, finalValue, value]);
+  }, [driver, initialValue, finalValue, value]);
 
   /**
    * Function to create a fade-in entry animation.
    */
   const entryAnimation = useCallback(
     () =>
-      Animated.timing(value, {
-        toValue: finalValue,
-        ...entryAnimationConfig,
-        useNativeDriver,
-      }),
-    [entryAnimationConfig, finalValue, useNativeDriver, value]
+      driver.timing(
+        value,
+        finalValue,
+        entryAnimationConfig
+      ) as DriverComposite<D>,
+    [driver, entryAnimationConfig, finalValue, value]
   );
 
   /**
@@ -108,12 +110,12 @@ export const useAnimation = ({
    */
   const exitAnimation = useCallback(
     () =>
-      Animated.timing(value, {
-        toValue: initialValue,
-        ...exitAnimationConfig,
-        useNativeDriver,
-      }),
-    [exitAnimationConfig, initialValue, useNativeDriver, value]
+      driver.timing(
+        value,
+        initialValue,
+        exitAnimationConfig
+      ) as DriverComposite<D>,
+    [driver, exitAnimationConfig, initialValue, value]
   );
 
   return { value, entryAnimation, exitAnimation };

--- a/src/hooks/useAnimation.ts
+++ b/src/hooks/useAnimation.ts
@@ -29,6 +29,11 @@ interface AnimationArgs<D extends AnimationDriver> {
    * Defaults to the entry animation config if not provided.
    */
   exitAnimationConfig?: DriverConfig<D>;
+  /**
+   * Whether to use the native animation driver.
+   * @default true
+   */
+  useNativeDriver?: boolean;
 }
 
 const EPSILON = 0.0001;
@@ -42,6 +47,7 @@ const EPSILON = 0.0001;
  * @param props.finalValue The end value of the animated value.
  * @param props.entryAnimationConfig The configuration for the entry animation.
  * @param props.exitAnimationConfig The configuration for the exit animation.
+ * @param props.useNativeDriver Whether to use the native animation driver. Defaults to true.
  * @returns The an object containing the animated value on which
  * the animation will be performed, the entry and exit animation function.
  */
@@ -51,6 +57,7 @@ export const useAnimation = <D extends AnimationDriver>({
   finalValue,
   entryAnimationConfig,
   exitAnimationConfig = entryAnimationConfig,
+  useNativeDriver = true,
 }: AnimationArgs<D>) => {
   const [value] = useState(
     () => driver.createValue(initialValue) as DriverValue<D>
@@ -100,9 +107,10 @@ export const useAnimation = <D extends AnimationDriver>({
       driver.timing(
         value,
         finalValue,
-        entryAnimationConfig
+        entryAnimationConfig,
+        useNativeDriver
       ) as DriverComposite<D>,
-    [driver, entryAnimationConfig, finalValue, value]
+    [driver, entryAnimationConfig, finalValue, useNativeDriver, value]
   );
 
   /**
@@ -113,9 +121,10 @@ export const useAnimation = <D extends AnimationDriver>({
       driver.timing(
         value,
         initialValue,
-        exitAnimationConfig
+        exitAnimationConfig,
+        useNativeDriver
       ) as DriverComposite<D>,
-    [driver, exitAnimationConfig, initialValue, value]
+    [driver, exitAnimationConfig, initialValue, useNativeDriver, value]
   );
 
   return { value, entryAnimation, exitAnimation };

--- a/src/hooks/useCombinedAnimation.ts
+++ b/src/hooks/useCombinedAnimation.ts
@@ -26,6 +26,11 @@ type UseCombinedAnimation = {
    * Defaults to context radius value if not provided.
    */
   radius?: number;
+  /**
+   * Whether to use the native animation driver for timing animations.
+   * @default true
+   */
+  useNativeDriver?: boolean;
 };
 
 /**
@@ -38,6 +43,7 @@ type UseCombinedAnimation = {
  * Defaults to the starting angle of the context if not provided.
  * @param props.radius The radius from which the component will start its linear animation.
  * Defaults to context radius value if not provided.
+ * @param props.useNativeDriver Whether to use the native animation driver. Defaults to true.
  * @returns An object containing animated value for the animation config passed,
  * the entry and exit functions and the visibility state of the component.
  */
@@ -46,6 +52,7 @@ export const useCombinedAnimation = ({
   radians,
   startAngle,
   radius,
+  useNativeDriver = true,
 }: UseCombinedAnimation) => {
   const {
     totalParts,
@@ -79,6 +86,7 @@ export const useCombinedAnimation = ({
     initialValue: 0,
     finalValue: 1,
     entryAnimationConfig: opacityAnimationConfig ?? {},
+    useNativeDriver,
   });
   // The value of opacity depending on the props of the component.
   const opacityValue = React.useMemo(
@@ -101,6 +109,7 @@ export const useCombinedAnimation = ({
     initialValue: 0,
     finalValue: radius ?? contextRadius,
     entryAnimationConfig: linearAnimationConfig ?? {},
+    useNativeDriver,
   });
   // The value of radius depending on the props of the component.
   const radiusValue = useMemo(
@@ -122,6 +131,7 @@ export const useCombinedAnimation = ({
     initialValue: startAngle ?? contextStartAngle,
     finalValue: radians,
     entryAnimationConfig: circularAnimationConfig ?? {},
+    useNativeDriver,
   });
   // The value of radians depending on the props of the component.
   const radiansValue = useMemo(

--- a/src/hooks/useCombinedAnimation.ts
+++ b/src/hooks/useCombinedAnimation.ts
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react';
-import { Animated } from 'react-native';
 
 import { CircleLayoutContext } from '../CircleLayoutContext';
 import { AnimationCombinationType, AnimationType } from '../types';
@@ -27,11 +26,6 @@ type UseCombinedAnimation = {
    * Defaults to context radius value if not provided.
    */
   radius?: number;
-  /**
-   * Whether to use the native animation driver for timing animations.
-   * @default true
-   */
-  useNativeDriver?: boolean;
 };
 
 /**
@@ -44,8 +38,6 @@ type UseCombinedAnimation = {
  * Defaults to the starting angle of the context if not provided.
  * @param props.radius The radius from which the component will start its linear animation.
  * Defaults to context radius value if not provided.
- * @param props.useNativeDriver Whether to use the native animation driver for timing animations.
- * Defaults to true.
  * @returns An object containing animated value for the animation config passed,
  * the entry and exit functions and the visibility state of the component.
  */
@@ -54,11 +46,11 @@ export const useCombinedAnimation = ({
   radians,
   startAngle,
   radius,
-  useNativeDriver = true,
 }: UseCombinedAnimation) => {
   const {
     totalParts,
     animationProps,
+    animationDriver: driver,
     radius: contextRadius,
     startAngle: contextStartAngle,
   } = React.use(CircleLayoutContext);
@@ -83,10 +75,10 @@ export const useCombinedAnimation = ({
     entryAnimation: opacityEntryAnimation,
     exitAnimation: opacityExitAnimation,
   } = useAnimation({
+    driver,
     initialValue: 0,
     finalValue: 1,
     entryAnimationConfig: opacityAnimationConfig ?? {},
-    useNativeDriver,
   });
   // The value of opacity depending on the props of the component.
   const opacityValue = React.useMemo(
@@ -105,10 +97,10 @@ export const useCombinedAnimation = ({
     entryAnimation: linearEntryAnimation,
     exitAnimation: linearExitAnimation,
   } = useAnimation({
+    driver,
     initialValue: 0,
     finalValue: radius ?? contextRadius,
     entryAnimationConfig: linearAnimationConfig ?? {},
-    useNativeDriver,
   });
   // The value of radius depending on the props of the component.
   const radiusValue = useMemo(
@@ -126,16 +118,18 @@ export const useCombinedAnimation = ({
     entryAnimation: circularEntryAnimation,
     exitAnimation: circularExitAnimation,
   } = useAnimation({
+    driver,
     initialValue: startAngle ?? contextStartAngle,
     finalValue: radians,
     entryAnimationConfig: circularAnimationConfig ?? {},
-    useNativeDriver,
   });
   // The value of radians depending on the props of the component.
   const radiansValue = useMemo(
     () => (circularAnimationConfig && animatedRadians) || radians,
     [circularAnimationConfig, radians, animatedRadians]
   );
+
+  type Composite = ReturnType<typeof driver.delay>;
 
   const { entryList: entryAnimationList, exitList: exitAnimationList } =
     React.useMemo(() => {
@@ -167,16 +161,16 @@ export const useCombinedAnimation = ({
             return { entryList: entry, exitList: exit };
           },
           {
-            entryList: [] as Animated.CompositeAnimation[],
-            exitList: [] as Animated.CompositeAnimation[],
+            entryList: [] as Composite[],
+            exitList: [] as Composite[],
           }
         );
 
       entryList.unshift(
-        Animated.delay(index * (animationProps.animationGap ?? 0))
+        driver.delay(index * (animationProps.animationGap ?? 0))
       );
       exitList.unshift(
-        Animated.delay(
+        driver.delay(
           (totalParts - index - 1) * (animationProps.animationGap ?? 0)
         )
       );
@@ -186,6 +180,7 @@ export const useCombinedAnimation = ({
       animationProps,
       circularEntryAnimation,
       circularExitAnimation,
+      driver,
       index,
       linearEntryAnimation,
       linearExitAnimation,
@@ -201,12 +196,12 @@ export const useCombinedAnimation = ({
     if (exitAnimationList) {
       switch (animationProps?.animationCombinationType) {
         case AnimationCombinationType.SEQUENCE:
-          Animated.sequence(exitAnimationList).start(() => {
+          driver.start(driver.sequence(exitAnimationList), () => {
             setComponentVisible(false);
           });
           break;
         default:
-          Animated.parallel(exitAnimationList).start(() => {
+          driver.start(driver.parallel(exitAnimationList), () => {
             setComponentVisible(false);
           });
           break;
@@ -214,7 +209,7 @@ export const useCombinedAnimation = ({
     } else {
       setComponentVisible(false);
     }
-  }, [animationProps?.animationCombinationType, exitAnimationList]);
+  }, [animationProps?.animationCombinationType, driver, exitAnimationList]);
 
   /**
    * Function to show the component by performing the animation configs passed.
@@ -223,12 +218,12 @@ export const useCombinedAnimation = ({
     if (entryAnimationList) {
       switch (animationProps?.animationCombinationType) {
         case AnimationCombinationType.SEQUENCE:
-          Animated.sequence(entryAnimationList).start(() => {
+          driver.start(driver.sequence(entryAnimationList), () => {
             setComponentVisible(true);
           });
           break;
         default:
-          Animated.parallel(entryAnimationList).start(() => {
+          driver.start(driver.parallel(entryAnimationList), () => {
             setComponentVisible(true);
           });
           break;
@@ -238,6 +233,7 @@ export const useCombinedAnimation = ({
     }
   }, [
     animationProps?.animationCombinationType,
+    driver,
     entryAnimationList,
     setComponentVisible,
   ]);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,3 +6,10 @@ export type {
   CircleLayoutProps,
   CircleLayoutRef,
 } from './types';
+export { rnAnimatedDriver } from './animation';
+export type {
+  AnimatedNode,
+  AnimationDriver,
+  DriverConfig,
+  RNAnimationConfig,
+} from './animation';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,8 @@
 import type { ReactNode } from 'react';
-import type {
-  Animated,
-  LayoutChangeEvent,
-  StyleProp,
-  ViewStyle,
-} from 'react-native';
+import type { LayoutChangeEvent, StyleProp, ViewStyle } from 'react-native';
+
+import type { AnimationDriver, DriverConfig } from './animation/types';
+import { rnAnimatedDriver } from './animation/rnAnimatedDriver';
 
 export enum AnimationType {
   /**
@@ -42,16 +40,18 @@ export enum AnimationCombinationType {
 }
 
 /**
- * The configuration for the animation.
+ * The configuration for the animation. The shape of this type is determined
+ * by the {@link AnimationDriver} in use — by default (the React Native
+ * `Animated`-backed driver) it mirrors `Animated.TimingAnimationConfig`.
  * @default undefined
+ * @see AnimationDriver
  * @see https://reactnative.dev/docs/animated#timing
  */
-export type AnimationConfig = Omit<
-  Animated.TimingAnimationConfig,
-  'toValue' | 'useNativeDriver'
->;
+export type AnimationConfig<
+  D extends AnimationDriver = typeof rnAnimatedDriver,
+> = DriverConfig<D>;
 
-type AnimationProps = {
+type AnimationProps<D extends AnimationDriver = typeof rnAnimatedDriver> = {
   /**
    * The configuration for the animation. The key of the record is the type of
    * animation and the value is the configuration for that animation. If a particular
@@ -71,7 +71,7 @@ type AnimationProps = {
    *  },
    * }
    */
-  animationConfigs: Partial<Record<AnimationType, AnimationConfig>>;
+  animationConfigs: Partial<Record<AnimationType, AnimationConfig<D>>>;
   /**
    * The type of composition animation to be performed with
    * all the animation configs provided.
@@ -127,7 +127,9 @@ export type BgConfig = {
   outerRadius?: number;
 };
 
-export type CircleLayoutProps = {
+export type CircleLayoutProps<
+  D extends AnimationDriver = typeof rnAnimatedDriver,
+> = {
   /**
    * The list of components that needs to be placed in the circle.
    */
@@ -169,13 +171,22 @@ export type CircleLayoutProps = {
    * @default undefined
    * @see AnimationProps
    */
-  animationProps?: AnimationProps;
+  animationProps?: AnimationProps<D>;
   /**
    * The fill color for the background of the circle layout.
    * If this prop is not provided, then the background will not be shown.
    * @default undefined
    */
   bgConfig?: BgConfig | undefined;
+  /**
+   * The animation driver used to power entry/exit and background animations.
+   * Defaults to a driver backed by React Native's core `Animated` API. Pass a
+   * custom driver to power animations with a different animation library
+   * (e.g. Reanimated, Moti).
+   * @default rnAnimatedDriver
+   * @see AnimationDriver
+   */
+  animationDriver?: D;
 };
 
 export type CircleLayoutRef = {
@@ -233,7 +244,9 @@ export type ComponentRef = {
   hideComponent: () => void;
 };
 
-export type CircleLayoutContextType = {
+export type CircleLayoutContextType<
+  D extends AnimationDriver = typeof rnAnimatedDriver,
+> = {
   /**
    * The total number of parts the circle is divided into.
    */
@@ -252,7 +265,11 @@ export type CircleLayoutContextType = {
    * The props for the animation.
    * @default undefined
    */
-  animationProps?: AnimationProps | undefined;
+  animationProps?: AnimationProps<D> | undefined;
+  /**
+   * The animation driver used to power entry/exit and background animations.
+   */
+  animationDriver: D;
   /**
    * The angle in radians between the position of 2 consecutive components on the circle.
    * This value is calculated by dividing the sweepAngle by the total number of parts.

--- a/src/utils/animation.ts
+++ b/src/utils/animation.ts
@@ -1,6 +1,4 @@
-import { Animated } from 'react-native';
-
-type InterpolationConfig = {
+export type InterpolationConfig = {
   /**
    * The start value of the input range.
    * @default 0
@@ -65,26 +63,3 @@ export const withFunction = <T extends number | string>(
   }
   return { inputRange, outputRange };
 };
-
-/**
- * Interpolates the value before updating the property using the callback function.
- * @param value The animated value that needs to be interpolated.
- * @param callback The function to use to create an output range by interpolating
- * the input range values.
- * @param interpolationConfig The configuration to be passed to the callback function.
- * @param animatedInterpolationConfig The configuration for the animated interpolation.
- * @returns Animated Interpolation value
- */
-export const interpolationWithFunction = <T extends number | string>(
-  value: Animated.Value | Animated.AnimatedInterpolation<number>,
-  callback: (value: number) => T,
-  interpolationConfig?: InterpolationConfig,
-  animatedInterpolationConfig?: Omit<
-    Animated.InterpolationConfig<number>,
-    'inputRange' | 'outputRange'
-  >
-): Animated.AnimatedInterpolation<T> =>
-  (value as Animated.Value).interpolate<T>({
-    ...withFunction(callback, interpolationConfig),
-    ...animatedInterpolationConfig,
-  });

--- a/src/utils/circle.ts
+++ b/src/utils/circle.ts
@@ -1,15 +1,13 @@
-import { Animated } from 'react-native';
-
-import { interpolationWithFunction } from './animation';
+import type { AnimatedNode, AnimationDriver } from '../animation/types';
 
 type Point = {
   x: number;
   y: number;
 };
 
-type PointAnimated = {
-  x: Animated.AnimatedInterpolation<number>;
-  y: Animated.AnimatedInterpolation<number>;
+type PointAnimated<D extends AnimationDriver> = {
+  x: AnimatedNode<D>;
+  y: AnimatedNode<D>;
 };
 
 /**
@@ -66,65 +64,71 @@ export function pointOnCircle({ radius, radians }: PointOnCircle): Point {
 /**
  * The props of the polar co-ordinate of a point on the circle.
  */
-export type PointOnCircleAnimated = {
+export type PointOnCircleAnimated<D extends AnimationDriver> = {
+  /**
+   * The driver used to power the animated interpolations.
+   */
+  driver: D;
   /**
    * The radius of the circle.
    */
-  radius: number | Animated.Value;
+  radius: number | AnimatedNode<D>;
   /**
    * The angle of the point on the circle.
    */
-  radians: number | Animated.Value;
+  radians: number | AnimatedNode<D>;
 };
 
 /**
  * Converts the polar co-ordinates of a point on a circle to its Cartesian co-ordinate,
- * supporting `Animated.Value` for radius and/or radians.
+ * supporting animated nodes (produced by the given driver) for radius and/or radians.
  * x = r cos θ, y = r sin θ
  * @param props The property of the circle
- * @param props.radius The radius of the circle. Can be a number or an `Animated.Value`.
- * @param props.radians The angle of the point on the circle. Can be a number or an `Animated.Value`.
+ * @param props.driver The driver used to power the animated interpolations.
+ * @param props.radius The radius of the circle. Can be a number or an animated node.
+ * @param props.radians The angle of the point on the circle. Can be a number or an animated node.
  * @returns The Cartesian co-ordinates of the point of the circle, interpolated when animated.
- * @throws {Error}  If neither `radius` nor `radians` is an `Animated.Value`. Use `pointOnCircle` for static values.
+ * @throws {Error}  If neither `radius` nor `radians` is an animated node. Use `pointOnCircle` for static values.
  */
-export function pointOnCircleAnimated({
+export function pointOnCircleAnimated<D extends AnimationDriver>({
+  driver,
   radians,
   radius,
-}: PointOnCircleAnimated): PointAnimated {
+}: PointOnCircleAnimated<D>): PointAnimated<D> {
   if (typeof radians === 'number') {
     if (typeof radius === 'number') {
       throw new Error(
-        'At least one of radius and radians needs to be an Animated.Value.' +
+        'At least one of radius and radians needs to be an animated node.' +
           ' Use pointOnCircle for static values.'
       );
     } else {
       return {
-        x: interpolationWithFunction(radius, (r) =>
+        x: driver.interpolate(radius, (r) =>
           pointOnCircleX({ radius: r, radians })
-        ),
-        y: interpolationWithFunction(radius, (r) =>
+        ) as AnimatedNode<D>,
+        y: driver.interpolate(radius, (r) =>
           pointOnCircleY({ radius: r, radians })
-        ),
+        ) as AnimatedNode<D>,
       };
     }
   } else {
     return {
-      x: Animated.multiply(
-        interpolationWithFunction(
+      x: driver.multiply(
+        driver.interpolate(
           radians,
           (rad) => pointOnCircleX({ radius: 1, radians: rad }),
           { endValue: 2 * Math.PI }
         ),
         radius
-      ),
-      y: Animated.multiply(
-        interpolationWithFunction(
+      ) as AnimatedNode<D>,
+      y: driver.multiply(
+        driver.interpolate(
           radians,
           (rad) => pointOnCircleY({ radius: 1, radians: rad }),
           { endValue: 2 * Math.PI }
         ),
         radius
-      ),
+      ) as AnimatedNode<D>,
     };
   }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,3 @@
-export { interpolationWithFunction } from './animation';
 export {
   getArcPath,
   getSectorPath,

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,3 +1,4 @@
+import type { AnimationDriver } from '../animation/types';
 import type { CircleLayoutProps } from '../types';
 
 /**
@@ -6,7 +7,9 @@ import type { CircleLayoutProps } from '../types';
  * @param props The properties passed to the component
  * @returns The validated properties
  */
-export function validateProps(props: CircleLayoutProps): CircleLayoutProps & {
+export function validateProps<D extends AnimationDriver>(
+  props: CircleLayoutProps<D>
+): CircleLayoutProps<D> & {
   sweepAngle: number;
   startAngle: number;
 } {


### PR DESCRIPTION
## Summary

- Introduces `AnimationDriver` abstraction so consumers can swap out the animation engine (e.g. Reanimated, Moti) via the `animationDriver` prop on `CircleLayout`
- Ships `rnAnimatedDriver` as the default implementation backed by RN core `Animated`
- Threads the driver generic through public API types, context, hooks, and components
- Restores `useNativeDriver` opt-out (required by `Bg` for SVG path animations that can't run on the native thread)

## What changed

| Area | Change |
|---|---|
| `AnimationDriver` interface | New abstraction covering `createValue`, `setValue`, `timing`, `sequence`, `parallel`, `delay`, `start`, `multiply`, `subtract`, `interpolate`, `isAnimatedValue`, `createAnimatedComponent` |
| `rnAnimatedDriver` | Default impl; `timing` accepts optional `useNativeDriver` (default `true`) |
| `useAnimation` / `useCombinedAnimation` | Inject driver; restore `useNativeDriver?: boolean` param forwarded to `driver.timing` |
| `Bg` | Passes `useNativeDriver: false` — SVG `d`-prop animation can't use native driver |
| `CircleLayout` / context | New `animationDriver` prop; falls back to `rnAnimatedDriver` |

## Test plan

- [ ] `pnpm test` — 171 tests, all pass (including the restored `allows disabling native driver explicitly` case)
- [ ] `pnpm typecheck` — no errors
- [ ] `pnpm lint` — clean
- [ ] Smoke-test example app: entry/exit animations run; background sector animates without crash