### PR TITLE
feat: weighted sectors, layout hooks, and per-sector styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-circle-layout",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "This package places components in a circle layout.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/src/Bg.tsx
+++ b/src/Bg.tsx
@@ -23,8 +23,8 @@ export const Bg = ({
   isVisible?: boolean;
 } & BgConfig) => {
   const {
-    startAngle,
-    sectorAngle,
+    sectorAngles,
+    componentAngles,
     animationDriver: driver,
   } = use(CircleLayoutContext);
 
@@ -39,12 +39,13 @@ export const Bg = ({
   );
 
   const { startAngleInRadians, endAngleInRadians } = useMemo(() => {
-    const angle = startAngle + index * sectorAngle;
+    const angle = componentAngles[index]!;
+    const sector = sectorAngles[index]!;
     return {
-      startAngleInRadians: angle - sectorAngle / 2,
-      endAngleInRadians: angle + sectorAngle / 2,
+      startAngleInRadians: angle - sector / 2,
+      endAngleInRadians: angle + sector / 2,
     };
-  }, [startAngle, sectorAngle, index]);
+  }, [componentAngles, sectorAngles, index]);
 
   const { size, center } = useMemo(() => {
     const padding = 0;

--- a/src/Bg.tsx
+++ b/src/Bg.tsx
@@ -42,8 +42,8 @@ export const Bg = ({
     const angle = componentAngles[index]!;
     const sector = sectorAngles[index]!;
     return {
-      startAngleInRadians: angle - sector / 2,
-      endAngleInRadians: angle + sector / 2,
+      startAngleInRadians: angle,
+      endAngleInRadians: angle + sector,
     };
   }, [componentAngles, sectorAngles, index]);
 

--- a/src/Bg.tsx
+++ b/src/Bg.tsx
@@ -1,5 +1,5 @@
 import Svg, { Path } from 'react-native-svg';
-import type { BgConfig, Layout } from './types';
+import type { ResolvedBgConfig, Layout } from './types';
 import { use, useLayoutEffect, useMemo } from 'react';
 import { useAnimatedSectorPath, useCombinedAnimation } from './hooks';
 import { CircleLayoutContext } from './CircleLayoutContext';
@@ -21,7 +21,7 @@ export const Bg = ({
   minComponentLayout: Layout;
   centerComponentLayout: Layout;
   isVisible?: boolean;
-} & BgConfig) => {
+} & ResolvedBgConfig) => {
   const {
     sectorAngles,
     componentAngles,

--- a/src/CircleLayout.tsx
+++ b/src/CircleLayout.tsx
@@ -38,6 +38,7 @@ export const CircleLayout = <D extends AnimationDriver>({
     animationProps,
     animationDriver,
     bgConfig,
+    weights,
   } = validateProps<D>(circleLayoutProps);
 
   return (
@@ -48,6 +49,7 @@ export const CircleLayout = <D extends AnimationDriver>({
       componentLength={components.length}
       animationProps={animationProps}
       animationDriver={animationDriver}
+      weights={weights}
     >
       <CircleLayoutContent
         ref={ref}

--- a/src/CircleLayoutArray.tsx
+++ b/src/CircleLayoutArray.tsx
@@ -78,7 +78,7 @@ function CircleLayoutArray({
     setMinComponentLayout(minLayout);
   }, [componentLayouts, setMinComponentLayout, sweepAngle]);
 
-  const { startAngle, totalParts, sectorAngle } = use(CircleLayoutContext);
+  const { startAngle, totalParts, componentAngles } = use(CircleLayoutContext);
 
   /**
    * The instance value that is exposed to parent components when using ref.
@@ -111,7 +111,7 @@ function CircleLayoutArray({
   }, [startAngle, sweepAngle, totalParts, isComponentsVisible]);
 
   return components.map((component, index) => {
-    const angle = (startAngle + sectorAngle * index) % (2 * Math.PI);
+    const angle = componentAngles[index]!;
     return (
       <CircleLayoutComponent
         component={component}

--- a/src/CircleLayoutArray.tsx
+++ b/src/CircleLayoutArray.tsx
@@ -108,7 +108,13 @@ function CircleLayoutArray({
         componentRef?.hideComponent()
       );
     }
-  }, [startAngle, sweepAngle, totalParts, isComponentsVisible]);
+  }, [
+    startAngle,
+    sweepAngle,
+    totalParts,
+    isComponentsVisible,
+    componentAngles,
+  ]);
 
   return components.map((component, index) => {
     const angle = componentAngles[index]!;

--- a/src/CircleLayoutContent.tsx
+++ b/src/CircleLayoutContent.tsx
@@ -1,9 +1,49 @@
 import { useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { type StyleProp, type ViewStyle, Animated, View } from 'react-native';
 import CircleLayoutArray from './CircleLayoutArray';
-import type { BgConfig, CircleLayoutRef, Layout } from './types';
+import type {
+  BgConfig,
+  CircleLayoutRef,
+  Layout,
+  ResolvedBgConfig,
+} from './types';
 import React from 'react';
 import { Bg } from './Bg';
+
+/**
+ * Resolves a per-sector style value from a scalar, array, or function.
+ * @param value The value to resolve — a single value, per-index array, or index function
+ * @param index The sector index to resolve for
+ * @returns The resolved scalar value for the given index
+ */
+function resolveValue<T>(
+  value: T | T[] | ((index: number) => T) | undefined,
+  index: number
+): T | undefined {
+  if (typeof value === 'function') {
+    return (value as (index: number) => T)(index);
+  }
+  if (Array.isArray(value)) {
+    return value[index];
+  }
+  return value;
+}
+
+/**
+ * Resolves a BgConfig with possible per-sector overrides into scalar values for one sector.
+ * @param bgConfig The raw BgConfig which may contain arrays or functions
+ * @param index The sector index to resolve for
+ * @returns A ResolvedBgConfig with scalar values only
+ */
+function resolveBgConfig(bgConfig: BgConfig, index: number): ResolvedBgConfig {
+  return {
+    color: resolveValue(bgConfig.color, index),
+    strokeColor: resolveValue(bgConfig.strokeColor, index),
+    strokeWidth: resolveValue(bgConfig.strokeWidth, index),
+    innerRadius: bgConfig.innerRadius,
+    outerRadius: bgConfig.outerRadius,
+  };
+}
 
 /**
  * The content of the CircleLayout component. This is separated from the main
@@ -100,7 +140,7 @@ export function CircleLayoutContent({
               centerComponentLayout={centerComponentLayout}
               radius={radius}
               isVisible={componentVisible}
-              {...bgConfig}
+              {...resolveBgConfig(bgConfig, index)}
             />
           ))}
         {/* The list of components to be shown in the circle. */}

--- a/src/CircleLayoutContext.tsx
+++ b/src/CircleLayoutContext.tsx
@@ -13,6 +13,7 @@ export const CircleLayoutContext = React.createContext<
   totalParts: 0,
   radius: 0,
   startAngle: 0,
-  sectorAngle: 0,
+  sectorAngles: [],
+  componentAngles: [],
   animationDriver: rnAnimatedDriver,
 });

--- a/src/CircleLayoutProvider.tsx
+++ b/src/CircleLayoutProvider.tsx
@@ -15,13 +15,14 @@ type CircleLayoutProviderProps = Required<
     | 'animationProps'
     | 'bgConfig'
     | 'animationDriver'
+    | 'weights'
   > & {
     componentLength: number;
   }
 > &
   Pick<
     CircleLayoutProps<AnimationDriver>,
-    'animationProps' | 'animationDriver'
+    'animationProps' | 'animationDriver' | 'weights'
   >;
 /**
  * A component that places a list of components in a circular layout.
@@ -33,6 +34,7 @@ type CircleLayoutProviderProps = Required<
  * @param props.children The child components to be rendered inside the circle layout.
  * @param props.animationProps The props for the animation.
  * @param props.animationDriver The animation driver used to power animations. Defaults to {@link rnAnimatedDriver}.
+ * @param props.weights Optional weights for data-proportional angular placement.
  * @see AnimationProps
  * @returns A component that places the passed components in a circular view.
  */
@@ -44,6 +46,7 @@ export const CircleLayoutProvider = ({
   children,
   animationProps,
   animationDriver = rnAnimatedDriver,
+  weights,
 }: React.PropsWithChildren<CircleLayoutProviderProps>) => {
   const isCompleteCircle = useMemo(
     () => Math.abs(sweepAngle - 2 * Math.PI) < 0.001,
@@ -56,6 +59,27 @@ export const CircleLayoutProvider = ({
     [componentLength, isCompleteCircle]
   );
 
+  const { sectorAngles, componentAngles } = React.useMemo(() => {
+    if (weights && weights.length === componentLength) {
+      const totalWeight = weights.reduce((sum, w) => sum + w, 0);
+      const sectors = weights.map((w) => (w / totalWeight) * sweepAngle);
+      let cumulative = startAngle;
+      const angles = sectors.map((s) => {
+        const angle = (cumulative + s / 2) % (2 * Math.PI);
+        cumulative += s;
+        return angle;
+      });
+      return { sectorAngles: sectors, componentAngles: angles };
+    }
+    const uniformSector = sweepAngle / totalParts;
+    const sectors = Array<number>(componentLength).fill(uniformSector);
+    const angles = Array.from(
+      { length: componentLength },
+      (_, i) => (startAngle + uniformSector * i) % (2 * Math.PI)
+    );
+    return { sectorAngles: sectors, componentAngles: angles };
+  }, [weights, componentLength, sweepAngle, startAngle, totalParts]);
+
   /**
    * The value passed to the context of the circle layout.
    */
@@ -66,15 +90,17 @@ export const CircleLayoutProvider = ({
       startAngle,
       animationProps,
       animationDriver,
-      sectorAngle: sweepAngle / totalParts,
+      sectorAngles,
+      componentAngles,
     }),
     [
       animationDriver,
       animationProps,
       radius,
       startAngle,
-      sweepAngle,
       totalParts,
+      sectorAngles,
+      componentAngles,
     ]
   );
 

--- a/src/CircleLayoutProvider.tsx
+++ b/src/CircleLayoutProvider.tsx
@@ -62,11 +62,17 @@ export const CircleLayoutProvider = ({
   const { sectorAngles, componentAngles } = React.useMemo(() => {
     if (weights && weights.length === componentLength) {
       const totalWeight = weights.reduce((sum, w) => sum + w, 0);
-      const sectors = weights.map((w) => (w / totalWeight) * sweepAngle);
+      const effectiveSweep = isCompleteCircle
+        ? sweepAngle
+        : (sweepAngle * totalWeight) /
+          (totalWeight - weights[weights.length - 1]!);
+      const sectors = weights.map((w) => (w / totalWeight) * effectiveSweep);
       let cumulative = startAngle;
-      const angles = sectors.map((s) => {
-        const angle = (cumulative + s / 2) % (2 * Math.PI);
-        cumulative += s;
+      const angles = sectors.map((s, i) => {
+        const angle = cumulative % (2 * Math.PI);
+        if (i < sectors.length - 1 || isCompleteCircle) {
+          cumulative += s;
+        }
         return angle;
       });
       return { sectorAngles: sectors, componentAngles: angles };
@@ -78,7 +84,14 @@ export const CircleLayoutProvider = ({
       (_, i) => (startAngle + uniformSector * i) % (2 * Math.PI)
     );
     return { sectorAngles: sectors, componentAngles: angles };
-  }, [weights, componentLength, sweepAngle, startAngle, totalParts]);
+  }, [
+    weights,
+    componentLength,
+    sweepAngle,
+    startAngle,
+    totalParts,
+    isCompleteCircle,
+  ]);
 
   /**
    * The value passed to the context of the circle layout.

--- a/src/__tests__/CircleLayout.test.tsx
+++ b/src/__tests__/CircleLayout.test.tsx
@@ -156,6 +156,42 @@ describe('validateProps', () => {
   });
 });
 
+describe('weights validation', () => {
+  it('throws when weights length does not match components length', () => {
+    expect(() => validateProps({ ...baseProps, weights: [1, 2, 3] })).toThrow(
+      'Weights length (3) must match components length (2)'
+    );
+  });
+
+  it('throws when any weight is 0', () => {
+    expect(() => validateProps({ ...baseProps, weights: [1, 0] })).toThrow(
+      'All weights must be greater than 0'
+    );
+  });
+
+  it('throws when any weight is negative', () => {
+    expect(() => validateProps({ ...baseProps, weights: [1, -1] })).toThrow(
+      'All weights must be greater than 0'
+    );
+  });
+
+  it('does not throw when weights are valid', () => {
+    expect(() =>
+      validateProps({ ...baseProps, weights: [1, 2] })
+    ).not.toThrow();
+  });
+
+  it('does not throw when weights are omitted', () => {
+    expect(() => validateProps(baseProps)).not.toThrow();
+  });
+
+  it('collects weights error with other errors', () => {
+    expect(() =>
+      validateProps({ components: [null], radius: -1, weights: [0] })
+    ).toThrow(/At least two.*\nRadius.*\nAll weights/s);
+  });
+});
+
 // ─── CircleLayout integration tests ─────────────────────────────────────────
 
 describe('CircleLayout', () => {
@@ -460,6 +496,73 @@ describe('CircleLayout', () => {
         />
       );
       expect(queryByText('C')).toBeNull();
+    });
+  });
+
+  describe('weighted angles', () => {
+    it('renders with equal weights (same as no weights)', () => {
+      expect(() =>
+        render(
+          <CircleLayout
+            components={makeComponents(3)}
+            radius={100}
+            weights={[1, 1, 1]}
+            ref={null}
+          />
+        )
+      ).not.toThrow();
+    });
+
+    it('renders with uneven weights', () => {
+      const { getAllByText } = render(
+        <CircleLayout
+          components={makeComponents(3)}
+          radius={100}
+          weights={[3, 1, 1]}
+          ref={null}
+        />
+      );
+      expect(getAllByText(/^Item \d$/)).toHaveLength(3);
+    });
+
+    it('renders with weights and bgConfig', () => {
+      expect(() =>
+        render(
+          <CircleLayout
+            components={makeComponents(3)}
+            radius={100}
+            weights={[2, 1, 1]}
+            bgConfig={{ color: 'red' }}
+            ref={null}
+          />
+        )
+      ).not.toThrow();
+    });
+
+    it('throws when weights length mismatches components', () => {
+      expect(() =>
+        render(
+          <CircleLayout
+            components={makeComponents(3)}
+            radius={100}
+            weights={[1, 2]}
+            ref={null}
+          />
+        )
+      ).toThrow('Weights length (2) must match components length (3)');
+    });
+
+    it('throws when a weight is zero', () => {
+      expect(() =>
+        render(
+          <CircleLayout
+            components={makeComponents(2)}
+            radius={100}
+            weights={[1, 0]}
+            ref={null}
+          />
+        )
+      ).toThrow('All weights must be greater than 0');
     });
   });
 });

--- a/src/__tests__/CircleLayout.test.tsx
+++ b/src/__tests__/CircleLayout.test.tsx
@@ -154,6 +154,65 @@ describe('validateProps', () => {
       ).not.toThrow();
     });
   });
+
+  describe('bgConfig array validation', () => {
+    it('passes when color is a single string', () => {
+      expect(() =>
+        validateProps({ ...baseProps, bgConfig: { color: 'red' } })
+      ).not.toThrow();
+    });
+
+    it('passes when color array length matches components', () => {
+      expect(() =>
+        validateProps({
+          ...baseProps,
+          bgConfig: { color: ['red', 'blue'] },
+        })
+      ).not.toThrow();
+    });
+
+    it('throws when color array length mismatches components', () => {
+      expect(() =>
+        validateProps({
+          ...baseProps,
+          bgConfig: { color: ['red'] },
+        })
+      ).toThrow(
+        'bgConfig.color array length (1) must match components length (2)'
+      );
+    });
+
+    it('throws when strokeColor array length mismatches components', () => {
+      expect(() =>
+        validateProps({
+          ...baseProps,
+          bgConfig: { strokeColor: ['red', 'blue', 'green'] },
+        })
+      ).toThrow(
+        'bgConfig.strokeColor array length (3) must match components length (2)'
+      );
+    });
+
+    it('throws when strokeWidth array length mismatches components', () => {
+      expect(() =>
+        validateProps({
+          ...baseProps,
+          bgConfig: { strokeWidth: [1] },
+        })
+      ).toThrow(
+        'bgConfig.strokeWidth array length (1) must match components length (2)'
+      );
+    });
+
+    it('passes when color is a function', () => {
+      expect(() =>
+        validateProps({
+          ...baseProps,
+          bgConfig: { color: (i: number) => (i === 0 ? 'red' : 'blue') },
+        })
+      ).not.toThrow();
+    });
+  });
 });
 
 describe('weights validation', () => {
@@ -267,6 +326,47 @@ describe('CircleLayout', () => {
         />
       );
       expect(UNSAFE_queryAllByType(Svg)).toHaveLength(3);
+    });
+
+    it('renders without throwing when color is a per-sector array', () => {
+      expect(() =>
+        render(
+          <CircleLayout
+            components={makeComponents(3)}
+            radius={100}
+            bgConfig={{ color: ['red', 'green', 'blue'] }}
+            ref={null}
+          />
+        )
+      ).not.toThrow();
+    });
+
+    it('renders without throwing when color is a function', () => {
+      expect(() =>
+        render(
+          <CircleLayout
+            components={makeComponents(3)}
+            radius={100}
+            bgConfig={{ color: (i: number) => ['red', 'green', 'blue'][i]! }}
+            ref={null}
+          />
+        )
+      ).not.toThrow();
+    });
+
+    it('throws when bgConfig color array length mismatches components', () => {
+      expect(() =>
+        render(
+          <CircleLayout
+            components={makeComponents(3)}
+            radius={100}
+            bgConfig={{ color: ['red', 'blue'] }}
+            ref={null}
+          />
+        )
+      ).toThrow(
+        'bgConfig.color array length (2) must match components length (3)'
+      );
     });
 
     it('renders without throwing when innerRadius and outerRadius are set', () => {

--- a/src/__tests__/CircleLayout.test.tsx
+++ b/src/__tests__/CircleLayout.test.tsx
@@ -1,9 +1,11 @@
-import { useRef } from 'react';
+import { use, useRef } from 'react';
 import { Text } from 'react-native';
 import Svg from 'react-native-svg';
 import { render, act, renderHook } from '@testing-library/react-native';
 
 import { CircleLayout } from '../CircleLayout';
+import { CircleLayoutContext } from '../CircleLayoutContext';
+import { CircleLayoutProvider } from '../CircleLayoutProvider';
 import type { CircleLayoutRef } from '../types';
 import { validateProps } from '../utils';
 
@@ -224,13 +226,13 @@ describe('weights validation', () => {
 
   it('throws when any weight is 0', () => {
     expect(() => validateProps({ ...baseProps, weights: [1, 0] })).toThrow(
-      'All weights must be greater than 0'
+      'All weights must be finite numbers greater than 0'
     );
   });
 
   it('throws when any weight is negative', () => {
     expect(() => validateProps({ ...baseProps, weights: [1, -1] })).toThrow(
-      'All weights must be greater than 0'
+      'All weights must be finite numbers greater than 0'
     );
   });
 
@@ -242,6 +244,24 @@ describe('weights validation', () => {
 
   it('does not throw when weights are omitted', () => {
     expect(() => validateProps(baseProps)).not.toThrow();
+  });
+
+  it('throws when any weight is NaN', () => {
+    expect(() => validateProps({ ...baseProps, weights: [1, NaN] })).toThrow(
+      'All weights must be finite numbers greater than 0'
+    );
+  });
+
+  it('throws when any weight is Infinity', () => {
+    expect(() =>
+      validateProps({ ...baseProps, weights: [1, Infinity] })
+    ).toThrow('All weights must be finite numbers greater than 0');
+  });
+
+  it('throws when any weight is -Infinity', () => {
+    expect(() =>
+      validateProps({ ...baseProps, weights: [1, -Infinity] })
+    ).toThrow('All weights must be finite numbers greater than 0');
   });
 
   it('collects weights error with other errors', () => {
@@ -662,7 +682,88 @@ describe('CircleLayout', () => {
             ref={null}
           />
         )
-      ).toThrow('All weights must be greater than 0');
+      ).toThrow('All weights must be finite numbers greater than 0');
     });
+  });
+});
+
+// ─── Weighted angle computation tests ─────────────────────────────────────────
+
+describe('CircleLayoutProvider weighted angles', () => {
+  let capturedContext: { componentAngles: number[]; sectorAngles: number[] };
+
+  const ContextCapture = () => {
+    const ctx = use(CircleLayoutContext);
+    capturedContext = {
+      componentAngles: ctx.componentAngles,
+      sectorAngles: ctx.sectorAngles,
+    };
+    return null;
+  };
+
+  const renderProvider = (
+    count: number,
+    sweepAngle = 2 * Math.PI,
+    weights?: number[]
+  ) => {
+    render(
+      <CircleLayoutProvider
+        sweepAngle={sweepAngle}
+        radius={100}
+        startAngle={0}
+        componentLength={count}
+        weights={weights}
+      >
+        <ContextCapture />
+      </CircleLayoutProvider>
+    );
+    return capturedContext;
+  };
+
+  it('equal weights produce same angles as uniform (full circle)', () => {
+    const uniform = renderProvider(3);
+    const weighted = renderProvider(3, 2 * Math.PI, [1, 1, 1]);
+
+    uniform.componentAngles.forEach((angle, i) => {
+      expect(weighted.componentAngles[i]).toBeCloseTo(angle, 5);
+    });
+    uniform.sectorAngles.forEach((sector, i) => {
+      expect(weighted.sectorAngles[i]).toBeCloseTo(sector, 5);
+    });
+  });
+
+  it('equal weights produce same angles as uniform (partial arc)', () => {
+    const sweep = Math.PI;
+    const uniform = renderProvider(3, sweep);
+    const weighted = renderProvider(3, sweep, [1, 1, 1]);
+
+    uniform.componentAngles.forEach((angle, i) => {
+      expect(weighted.componentAngles[i]).toBeCloseTo(angle, 5);
+    });
+  });
+
+  it('first component placed at startAngle with weights (full circle)', () => {
+    const ctx = renderProvider(3, 2 * Math.PI, [3, 1, 1]);
+    expect(ctx.componentAngles[0]).toBeCloseTo(0, 5);
+  });
+
+  it('last component at startAngle + sweepAngle (partial arc)', () => {
+    const sweep = Math.PI;
+    const ctx = renderProvider(3, sweep, [2, 1, 1]);
+    expect(ctx.componentAngles[ctx.componentAngles.length - 1]).toBeCloseTo(
+      sweep,
+      5
+    );
+  });
+
+  it('sector angles are proportional to weights', () => {
+    const ctx = renderProvider(2, 2 * Math.PI, [2, 1]);
+    expect(ctx.sectorAngles[0]! / ctx.sectorAngles[1]!).toBeCloseTo(2, 5);
+  });
+
+  it('sector angles sum to sweepAngle (full circle)', () => {
+    const ctx = renderProvider(3, 2 * Math.PI, [3, 1, 2]);
+    const sum = ctx.sectorAngles.reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(2 * Math.PI, 5);
   });
 });

--- a/src/__tests__/CircleLayoutArray.test.tsx
+++ b/src/__tests__/CircleLayoutArray.test.tsx
@@ -11,12 +11,19 @@ import type {
   Layout,
 } from '../types';
 
-const baseContext: CircleLayoutContextType = {
-  totalParts: 2,
-  radius: 100,
-  startAngle: 0,
-  sectorAngle: Math.PI,
-  animationDriver: rnAnimatedDriver,
+const makeContext = (n: number): CircleLayoutContextType => {
+  const sectorAngle = (2 * Math.PI) / n;
+  return {
+    totalParts: n,
+    radius: 100,
+    startAngle: 0,
+    sectorAngles: Array<number>(n).fill(sectorAngle),
+    componentAngles: Array.from(
+      { length: n },
+      (_, i) => (sectorAngle * i) % (2 * Math.PI)
+    ),
+    animationDriver: rnAnimatedDriver,
+  };
 };
 
 const noopSetLayout = () => {};
@@ -27,15 +34,16 @@ const makeComponents = (n: number) =>
 
 const renderArray = (
   components: React.ReactNode[],
-  ctx: CircleLayoutContextType = baseContext,
+  ctx?: CircleLayoutContextType,
   props: Partial<{
     setMinComponentLayout: React.Dispatch<React.SetStateAction<Layout>>;
     centerComponentLayout: Layout;
     ref: React.Ref<CircleLayoutRef>;
   }> = {}
-) =>
-  render(
-    <CircleLayoutContext value={ctx}>
+) => {
+  const context = ctx ?? makeContext(components.length);
+  return render(
+    <CircleLayoutContext value={context}>
       <View>
         <CircleLayoutArray
           components={components}
@@ -49,6 +57,7 @@ const renderArray = (
       </View>
     </CircleLayoutContext>
   );
+};
 
 describe('CircleLayoutArray', () => {
   describe('rendering', () => {
@@ -78,7 +87,7 @@ describe('CircleLayoutArray', () => {
         <Text key="B">B</Text>,
       ]);
       rerender(
-        <CircleLayoutContext value={baseContext}>
+        <CircleLayoutContext value={makeContext(3)}>
           <View>
             <CircleLayoutArray
               components={[
@@ -104,7 +113,7 @@ describe('CircleLayoutArray', () => {
         <Text key="C">C</Text>,
       ]);
       rerender(
-        <CircleLayoutContext value={baseContext}>
+        <CircleLayoutContext value={makeContext(2)}>
           <View>
             <CircleLayoutArray
               components={[<Text key="A">A</Text>, <Text key="B">B</Text>]}
@@ -124,7 +133,7 @@ describe('CircleLayoutArray', () => {
     it('exposes showComponents and hideComponents via ref', () => {
       const { result } = renderHook(() => useRef<CircleLayoutRef>(null));
       const ref = result.current;
-      renderArray(makeComponents(3), baseContext, { ref });
+      renderArray(makeComponents(3), makeContext(3), { ref });
       expect(typeof ref.current?.showComponents).toBe('function');
       expect(typeof ref.current?.hideComponents).toBe('function');
     });
@@ -132,7 +141,7 @@ describe('CircleLayoutArray', () => {
     it('showComponents and hideComponents execute without throwing', () => {
       const { result } = renderHook(() => useRef<CircleLayoutRef>(null));
       const ref = result.current;
-      renderArray(makeComponents(3), baseContext, { ref });
+      renderArray(makeComponents(3), makeContext(3), { ref });
       expect(() => {
         act(() => {
           ref.current?.hideComponents();
@@ -145,7 +154,7 @@ describe('CircleLayoutArray', () => {
   describe('setMinComponentLayout callback', () => {
     it('calls setMinComponentLayout with layout dimensions after render', () => {
       const setMinComponentLayout = jest.fn();
-      renderArray(makeComponents(3), baseContext, { setMinComponentLayout });
+      renderArray(makeComponents(3), makeContext(3), { setMinComponentLayout });
       expect(setMinComponentLayout).toHaveBeenCalled();
     });
   });
@@ -162,7 +171,7 @@ describe('CircleLayoutArray', () => {
     it('renders with sweepAngle < 2π (quarter-circle)', () => {
       expect(() =>
         render(
-          <CircleLayoutContext value={baseContext}>
+          <CircleLayoutContext value={makeContext(4)}>
             <View>
               <CircleLayoutArray
                 components={makeComponents(4)}
@@ -179,7 +188,7 @@ describe('CircleLayoutArray', () => {
 
     it('renders with non-zero centerComponentLayout without throwing', () => {
       expect(() =>
-        renderArray(makeComponents(3), baseContext, {
+        renderArray(makeComponents(3), makeContext(3), {
           centerComponentLayout: { width: 50, height: 50 },
         })
       ).not.toThrow();
@@ -187,12 +196,12 @@ describe('CircleLayoutArray', () => {
 
     it('calls setMinComponentLayout again when components grow', () => {
       const setMinComponentLayout = jest.fn();
-      const { rerender } = renderArray(makeComponents(3), baseContext, {
+      const { rerender } = renderArray(makeComponents(3), makeContext(3), {
         setMinComponentLayout,
       });
       const callsBefore = setMinComponentLayout.mock.calls.length;
       rerender(
-        <CircleLayoutContext value={baseContext}>
+        <CircleLayoutContext value={makeContext(5)}>
           <View>
             <CircleLayoutArray
               components={makeComponents(5)}
@@ -212,7 +221,7 @@ describe('CircleLayoutArray', () => {
     it('rapid hide then show via ref does not throw', () => {
       const { result } = renderHook(() => useRef<CircleLayoutRef>(null));
       const ref = result.current;
-      renderArray(makeComponents(3), baseContext, { ref });
+      renderArray(makeComponents(3), makeContext(3), { ref });
       expect(() => {
         act(() => {
           ref.current?.hideComponents();

--- a/src/__tests__/CircleLayoutComponent.test.tsx
+++ b/src/__tests__/CircleLayoutComponent.test.tsx
@@ -17,7 +17,8 @@ const baseContext: CircleLayoutContextType = {
   totalParts: 3,
   radius: 100,
   startAngle: 0,
-  sectorAngle: (2 * Math.PI) / 3,
+  sectorAngles: Array(3).fill((2 * Math.PI) / 3),
+  componentAngles: [0, (2 * Math.PI) / 3, (4 * Math.PI) / 3],
   animationDriver: rnAnimatedDriver,
 };
 

--- a/src/__tests__/hooks/useCirclePositions.test.ts
+++ b/src/__tests__/hooks/useCirclePositions.test.ts
@@ -1,0 +1,104 @@
+import { renderHook } from '@testing-library/react-native';
+import { useCirclePosition, useCirclePositions } from '../../hooks';
+
+describe('useCirclePositions', () => {
+  it('returns empty array for count 0', () => {
+    const { result } = renderHook(() =>
+      useCirclePositions({ count: 0, radius: 100 })
+    );
+    expect(result.current).toEqual([]);
+  });
+
+  it('distributes positions evenly around full circle', () => {
+    const { result } = renderHook(() =>
+      useCirclePositions({ count: 4, radius: 100 })
+    );
+    expect(result.current).toHaveLength(4);
+
+    // First item at angle 0: x=100, y=0
+    expect(result.current[0]!.x).toBeCloseTo(100);
+    expect(result.current[0]!.y).toBeCloseTo(0);
+    expect(result.current[0]!.angle).toBeCloseTo(0);
+
+    // Second item at π/2: x=0, y=100
+    expect(result.current[1]!.x).toBeCloseTo(0);
+    expect(result.current[1]!.y).toBeCloseTo(100);
+    expect(result.current[1]!.angle).toBeCloseTo(Math.PI / 2);
+
+    // Third item at π: x=-100, y=0
+    expect(result.current[2]!.x).toBeCloseTo(-100);
+    expect(result.current[2]!.y).toBeCloseTo(0);
+    expect(result.current[2]!.angle).toBeCloseTo(Math.PI);
+
+    // Fourth item at 3π/2: x=0, y=-100
+    expect(result.current[3]!.x).toBeCloseTo(0);
+    expect(result.current[3]!.y).toBeCloseTo(-100);
+    expect(result.current[3]!.angle).toBeCloseTo((3 * Math.PI) / 2);
+  });
+
+  it('respects startAngle', () => {
+    const { result } = renderHook(() =>
+      useCirclePositions({
+        count: 2,
+        radius: 100,
+        startAngle: Math.PI / 2,
+      })
+    );
+    // First item at π/2
+    expect(result.current[0]!.angle).toBeCloseTo(Math.PI / 2);
+    expect(result.current[0]!.x).toBeCloseTo(0);
+    expect(result.current[0]!.y).toBeCloseTo(100);
+  });
+
+  it('distributes over partial sweep (not complete circle)', () => {
+    const { result } = renderHook(() =>
+      useCirclePositions({
+        count: 3,
+        radius: 100,
+        startAngle: 0,
+        sweepAngle: Math.PI,
+      })
+    );
+    expect(result.current).toHaveLength(3);
+
+    // For non-complete circle: totalParts = count - 1 = 2
+    // sectorAngle = π/2
+    expect(result.current[0]!.angle).toBeCloseTo(0);
+    expect(result.current[1]!.angle).toBeCloseTo(Math.PI / 2);
+    expect(result.current[2]!.angle).toBeCloseTo(Math.PI);
+  });
+
+  it('handles single item', () => {
+    const { result } = renderHook(() =>
+      useCirclePositions({ count: 1, radius: 50 })
+    );
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]!.x).toBeCloseTo(50);
+    expect(result.current[0]!.y).toBeCloseTo(0);
+  });
+});
+
+describe('useCirclePosition', () => {
+  it('returns position for a single index', () => {
+    const { result } = renderHook(() =>
+      useCirclePosition({ index: 1, count: 4, radius: 100 })
+    );
+    // Second item in 4-item full circle: angle = π/2
+    expect(result.current.angle).toBeCloseTo(Math.PI / 2);
+    expect(result.current.x).toBeCloseTo(0);
+    expect(result.current.y).toBeCloseTo(100);
+  });
+
+  it('matches useCirclePositions output', () => {
+    const { result: allResult } = renderHook(() =>
+      useCirclePositions({ count: 6, radius: 120, startAngle: 0.5 })
+    );
+    const { result: singleResult } = renderHook(() =>
+      useCirclePosition({ index: 3, count: 6, radius: 120, startAngle: 0.5 })
+    );
+
+    expect(singleResult.current.x).toBeCloseTo(allResult.current[3]!.x);
+    expect(singleResult.current.y).toBeCloseTo(allResult.current[3]!.y);
+    expect(singleResult.current.angle).toBeCloseTo(allResult.current[3]!.angle);
+  });
+});

--- a/src/__tests__/hooks/useCombinedAnimation.test.tsx
+++ b/src/__tests__/hooks/useCombinedAnimation.test.tsx
@@ -19,7 +19,8 @@ const baseContext: CircleLayoutContextType = {
   totalParts: 3,
   radius: 100,
   startAngle: 0,
-  sectorAngle: (2 * Math.PI) / 3,
+  sectorAngles: Array(3).fill((2 * Math.PI) / 3),
+  componentAngles: [0, (2 * Math.PI) / 3, (4 * Math.PI) / 3],
   animationDriver: rnAnimatedDriver,
 };
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,8 @@
 export { useAnimatedSectorPath } from './useAnimatedSectorPath';
 export { useAnimation } from './useAnimation';
+export { useCirclePosition, useCirclePositions } from './useCirclePositions';
+export type {
+  CirclePosition,
+  CirclePositionsConfig,
+} from './useCirclePositions';
 export { useCombinedAnimation } from './useCombinedAnimation';

--- a/src/hooks/useCirclePositions.ts
+++ b/src/hooks/useCirclePositions.ts
@@ -14,6 +14,12 @@ export type CirclePositionsConfig = {
   sweepAngle?: number;
 };
 
+/** Normalizes multiples of 2π back to 2π, matching validateProps behavior. */
+function normalizeSweepAngle(sweepAngle: number): number {
+  const mod = sweepAngle % (2 * Math.PI);
+  return mod === 0 ? 2 * Math.PI : mod;
+}
+
 /**
  * Computes the position of a point on a circle.
  * @param index - The index of the point.
@@ -51,9 +57,10 @@ export function useCirclePositions({
   return useMemo(() => {
     if (count <= 0) return [];
 
-    const isCompleteCircle = Math.abs(sweepAngle - 2 * Math.PI) < 0.001;
+    const normalized = normalizeSweepAngle(sweepAngle);
+    const isCompleteCircle = Math.abs(normalized - 2 * Math.PI) < 0.001;
     const totalParts = isCompleteCircle ? count : count - 1;
-    const sectorAngle = totalParts > 0 ? sweepAngle / totalParts : 0;
+    const sectorAngle = totalParts > 0 ? normalized / totalParts : 0;
 
     return Array.from({ length: count }, (_, index) =>
       computePosition(index, sectorAngle, startAngle, radius)
@@ -79,9 +86,10 @@ export function useCirclePosition({
   sweepAngle = 2 * Math.PI,
 }: CirclePositionsConfig & { index: number }): CirclePosition {
   return useMemo(() => {
-    const isCompleteCircle = Math.abs(sweepAngle - 2 * Math.PI) < 0.001;
+    const normalized = normalizeSweepAngle(sweepAngle);
+    const isCompleteCircle = Math.abs(normalized - 2 * Math.PI) < 0.001;
     const totalParts = isCompleteCircle ? count : count - 1;
-    const sectorAngle = totalParts > 0 ? sweepAngle / totalParts : 0;
+    const sectorAngle = totalParts > 0 ? normalized / totalParts : 0;
 
     return computePosition(index, sectorAngle, startAngle, radius);
   }, [index, count, radius, startAngle, sweepAngle]);

--- a/src/hooks/useCirclePositions.ts
+++ b/src/hooks/useCirclePositions.ts
@@ -1,0 +1,88 @@
+import { useMemo } from 'react';
+import { pointOnCircle } from '../utils';
+
+export type CirclePosition = {
+  x: number;
+  y: number;
+  angle: number;
+};
+
+export type CirclePositionsConfig = {
+  count: number;
+  radius: number;
+  startAngle?: number;
+  sweepAngle?: number;
+};
+
+/**
+ * Computes the position of a point on a circle.
+ * @param index - The index of the point.
+ * @param sectorAngle - The angle of the sector.
+ * @param startAngle - The starting angle.
+ * @param radius - The radius of the circle.
+ * @returns The position of the point on the circle.
+ */
+function computePosition(
+  index: number,
+  sectorAngle: number,
+  startAngle: number,
+  radius: number
+): CirclePosition {
+  const angle = (startAngle + sectorAngle * index) % (2 * Math.PI);
+  const { x, y } = pointOnCircle({ radius, radians: angle });
+  return { x, y, angle };
+}
+
+/**
+ * Computes the positions of points on a circle.
+ * @param param - The configuration object.
+ * @param param.count - The number of points.
+ * @param param.radius - The radius of the circle.
+ * @param param.startAngle - The starting angle.
+ * @param param.sweepAngle - The sweep angle.
+ * @returns An array of positions of the points on the circle.
+ */
+export function useCirclePositions({
+  count,
+  radius,
+  startAngle = 0,
+  sweepAngle = 2 * Math.PI,
+}: CirclePositionsConfig): CirclePosition[] {
+  return useMemo(() => {
+    if (count <= 0) return [];
+
+    const isCompleteCircle = Math.abs(sweepAngle - 2 * Math.PI) < 0.001;
+    const totalParts = isCompleteCircle ? count : count - 1;
+    const sectorAngle = totalParts > 0 ? sweepAngle / totalParts : 0;
+
+    return Array.from({ length: count }, (_, index) =>
+      computePosition(index, sectorAngle, startAngle, radius)
+    );
+  }, [count, radius, startAngle, sweepAngle]);
+}
+
+/**
+ * Computes the position of a single point on a circle.
+ * @param param - The configuration object.
+ * @param param.index - The index of the point.
+ * @param param.count - The number of points.
+ * @param param.radius - The radius of the circle.
+ * @param param.startAngle - The starting angle.
+ * @param param.sweepAngle - The sweep angle.
+ * @returns The position of the point on the circle.
+ */
+export function useCirclePosition({
+  index,
+  count,
+  radius,
+  startAngle = 0,
+  sweepAngle = 2 * Math.PI,
+}: CirclePositionsConfig & { index: number }): CirclePosition {
+  return useMemo(() => {
+    const isCompleteCircle = Math.abs(sweepAngle - 2 * Math.PI) < 0.001;
+    const totalParts = isCompleteCircle ? count : count - 1;
+    const sectorAngle = totalParts > 0 ? sweepAngle / totalParts : 0;
+
+    return computePosition(index, sectorAngle, startAngle, radius);
+  }, [index, count, radius, startAngle, sweepAngle]);
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,3 @@
-export { CircleLayout } from './CircleLayout';
-export { AnimationCombinationType, AnimationType } from './types';
-export type {
-  AnimationConfig,
-  BgConfig,
-  CircleLayoutProps,
-  CircleLayoutRef,
-} from './types';
 export { rnAnimatedDriver } from './animation';
 export type {
   AnimatedNode,
@@ -13,3 +5,15 @@ export type {
   DriverConfig,
   RNAnimationConfig,
 } from './animation';
+export { CircleLayout } from './CircleLayout';
+export { useCirclePosition, useCirclePositions } from './hooks';
+export type { CirclePosition, CirclePositionsConfig } from './hooks';
+export { AnimationCombinationType, AnimationType } from './types';
+export type {
+  AnimationConfig,
+  BgConfig,
+  CircleLayoutProps,
+  CircleLayoutRef,
+} from './types';
+export { pointOnCircle, pointOnCircleX, pointOnCircleY } from './utils';
+export type { PointOnCircle } from './utils';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ export type {
   BgConfig,
   CircleLayoutProps,
   CircleLayoutRef,
+  ResolvedBgConfig,
 } from './types';
 export { pointOnCircle, pointOnCircleX, pointOnCircleY } from './utils';
 export type { PointOnCircle } from './utils';

--- a/src/types.ts
+++ b/src/types.ts
@@ -298,7 +298,9 @@ export type CircleLayoutContextType<
    */
   componentAngles: number[];
   /**
-   * The angular width (in radians) of each component's sector.
+   * The angular span (in radians) from each component's placement angle to the
+   * next component. For complete circles the last entry spans from the last
+   * component back to the first; for partial arcs it covers the remaining arc.
    * Length equals the number of components.
    */
   sectorAngles: number[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,6 +187,14 @@ export type CircleLayoutProps<
    * @see AnimationDriver
    */
   animationDriver?: D;
+  /**
+   * Optional weights for data-proportional angular placement. Each weight
+   * controls the angular share of the corresponding component. When omitted,
+   * all components receive equal spacing. Length must match `components`.
+   * All values must be greater than 0.
+   * @default undefined
+   */
+  weights?: number[];
 };
 
 export type CircleLayoutRef = {
@@ -271,10 +279,15 @@ export type CircleLayoutContextType<
    */
   animationDriver: D;
   /**
-   * The angle in radians between the position of 2 consecutive components on the circle.
-   * This value is calculated by dividing the sweepAngle by the total number of parts.
+   * The absolute angle (in radians) at which each component is placed.
+   * Length equals the number of components.
    */
-  sectorAngle: number;
+  componentAngles: number[];
+  /**
+   * The angular width (in radians) of each component's sector.
+   * Length equals the number of components.
+   */
+  sectorAngles: number[];
 };
 
 export type Layout = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,19 +92,25 @@ type AnimationProps<D extends AnimationDriver = typeof rnAnimatedDriver> = {
 export type BgConfig = {
   /**
    * The fill color for the background of the circle layout.
+   * A single value applies to all sectors. An array or function
+   * provides per-sector styling (length must match components).
    * @default #3d19e0
    */
-  color?: string;
+  color?: string | string[] | ((index: number) => string);
   /**
    * The stroke color for the divider lines in the background.
+   * A single value applies to all sectors. An array or function
+   * provides per-sector styling (length must match components).
    * @default color
    */
-  strokeColor?: string;
+  strokeColor?: string | string[] | ((index: number) => string);
   /**
    * The width of the stroke for the divider lines in the background.
+   * A single value applies to all sectors. An array or function
+   * provides per-sector styling (length must match components).
    * @default 1
    */
-  strokeWidth?: number;
+  strokeWidth?: number | number[] | ((index: number) => number);
   /**
    * The radius of the inner circle in the background.
    * If this prop is not provided, then there will be no inner circle in
@@ -124,6 +130,14 @@ export type BgConfig = {
    * @see CircleLayoutProps.radius
    * @see BgConfig.innerRadius
    */
+  outerRadius?: number;
+};
+
+export type ResolvedBgConfig = {
+  color?: string;
+  strokeColor?: string;
+  strokeWidth?: number;
+  innerRadius?: number;
   outerRadius?: number;
 };
 

--- a/src/utils/circle.ts
+++ b/src/utils/circle.ts
@@ -31,7 +31,7 @@ export type PointOnCircle = {
  * @param props.radians The angle of the point on the circle.
  * @returns The x co-ordinate of the point on the circle.
  */
-function pointOnCircleX({ radius, radians }: PointOnCircle): number {
+export function pointOnCircleX({ radius, radians }: PointOnCircle): number {
   return radius * Math.cos(radians);
 }
 
@@ -42,7 +42,7 @@ function pointOnCircleX({ radius, radians }: PointOnCircle): number {
  * @param props.radians The angle of the point on the circle.
  * @returns The y co-ordinate of the point on the circle.
  */
-function pointOnCircleY({ radius, radians }: PointOnCircle): number {
+export function pointOnCircleY({ radius, radians }: PointOnCircle): number {
   return radius * Math.sin(radians);
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,6 +4,8 @@ export {
   getSectorPath,
   pointOnCircle,
   pointOnCircleAnimated,
+  pointOnCircleX,
+  pointOnCircleY,
 } from './circle';
 export type { PointOnCircle, PointOnCircleAnimated } from './circle';
 export { validateProps } from './validation';

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -31,7 +31,7 @@ export function validateProps<D extends AnimationDriver>(
         `Weights length (${props.weights.length}) must match components length (${props.components.length})`
       );
     }
-    if (props.weights.some((w) => w <= 0)) {
+    if (props.weights.some((w) => w <= 0 && Number.isFinite(w))) {
       errors.push('All weights must be greater than 0');
     }
   }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -36,6 +36,26 @@ export function validateProps<D extends AnimationDriver>(
     }
   }
 
+  if (props.bgConfig) {
+    const count = props.components.length;
+    const { color, strokeColor, strokeWidth } = props.bgConfig;
+    if (Array.isArray(color) && color.length !== count) {
+      errors.push(
+        `bgConfig.color array length (${color.length}) must match components length (${count})`
+      );
+    }
+    if (Array.isArray(strokeColor) && strokeColor.length !== count) {
+      errors.push(
+        `bgConfig.strokeColor array length (${strokeColor.length}) must match components length (${count})`
+      );
+    }
+    if (Array.isArray(strokeWidth) && strokeWidth.length !== count) {
+      errors.push(
+        `bgConfig.strokeWidth array length (${strokeWidth.length}) must match components length (${count})`
+      );
+    }
+  }
+
   if (errors.length > 0) {
     throw new Error(errors.join('\n'));
   }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -25,6 +25,17 @@ export function validateProps<D extends AnimationDriver>(
     errors.push('Sweep angle cannot be 0');
   }
 
+  if (props.weights !== undefined) {
+    if (props.weights.length !== props.components.length) {
+      errors.push(
+        `Weights length (${props.weights.length}) must match components length (${props.components.length})`
+      );
+    }
+    if (props.weights.some((w) => w <= 0)) {
+      errors.push('All weights must be greater than 0');
+    }
+  }
+
   if (errors.length > 0) {
     throw new Error(errors.join('\n'));
   }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -31,8 +31,8 @@ export function validateProps<D extends AnimationDriver>(
         `Weights length (${props.weights.length}) must match components length (${props.components.length})`
       );
     }
-    if (props.weights.some((w) => w <= 0 && Number.isFinite(w))) {
-      errors.push('All weights must be greater than 0');
+    if (props.weights.some((w) => !Number.isFinite(w) || w <= 0)) {
+      errors.push('All weights must be finite numbers greater than 0');
     }
   }
 


### PR DESCRIPTION
## Summary
- **Weighted sector angles**: support `weights` prop to control relative sector sizes, with validation
- **Circle layout hooks**: expose `useCirclePosition` and `useCirclePositions` for using layout math outside the component
- **Per-sector BgConfig**: support arrays for `color`, `strokeColor`, and `strokeWidth` in `BgConfig` for individual sector styling

Merges branches:
- `claude/agitated-volhard-865ee8` (weighted sectors)
- `claude/inspiring-euclid-94206a` (layout hooks)
- `claude/jovial-beaver-0f3668` (per-sector styling)

## Test plan
- [x] All 560 existing + new tests pass
- [x] Type checking passes
- [ ] Verify weighted sectors render correctly in example app
- [ ] Verify per-sector colors render correctly in example app
- [ ] Verify hooks return correct positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)